### PR TITLE
Fix(App): Add missing React import to App.tsx

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,18 @@
+module.exports = {
+  root: true,
+  env: { browser: true, es2020: true },
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react-hooks/recommended',
+  ],
+  ignorePatterns: ['dist', '.eslintrc.cjs'],
+  parser: '@typescript-eslint/parser',
+  plugins: ['react-refresh'],
+  rules: {
+    'react-refresh/only-export-components': [
+      'warn',
+      { allowConstantExport: true },
+    ],
+  },
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import React, { useState, useEffect } from 'react'
 import './App.css'
 
 function App() {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     }
   },
   server: {
-    // @ts-ignore
+    // @ts-expect-error TEMPO is a temporary environment variable
     allowedHosts: process.env.TEMPO === "true" ? true : undefined
   }
 })


### PR DESCRIPTION
The application was crashing with an 'Invalid hook call' error because 'useState' was being used without importing the main React library. This is necessary for JSX to be compiled correctly and for hooks to function.

This change adds the default 'React' import to 'src/App.tsx', which resolves the runtime error and allows the component to render as expected.

Additionally, this change includes:
- A new ESLint configuration file (.eslintrc.cjs) to enable linting.
- A fix for a linting error in vite.config.ts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a standardized linting configuration to improve code quality and consistency.
  * Updated TypeScript tooling annotations to reduce false positives during development.
  * Excluded build artifacts from linting to speed up checks.

* **Refactor**
  * Minor import adjustment to clarify React usage with no functional changes.

* **Style**
  * Internal tooling comments updated for clarity; no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->