### PR TITLE
feat: Implement splash screen

### DIFF
--- a/Kuve-AKU-1/src/App.css
+++ b/Kuve-AKU-1/src/App.css
@@ -17,6 +17,8 @@ body {
   justify-content: center;
   overflow-y: auto; /* Enable vertical scrolling */
   padding: 2rem 0; /* Add vertical padding */
+  background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
+  animation: gradientShift 8s ease-in-out infinite;
 }
 
 /* Animated Background */
@@ -26,8 +28,6 @@ body {
   left: 0;
   width: 100%;
   height: 100%;
-  background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
-  animation: gradientShift 8s ease-in-out infinite;
   z-index: -2;
 }
 

--- a/Kuve-AKU-1/src/App.tsx
+++ b/Kuve-AKU-1/src/App.tsx
@@ -1,32 +1,42 @@
-import React, { useState, useEffect } from 'react'
-import './App.css'
+import React, { useState, useEffect } from 'react';
+import SplashScreen from './SplashScreen';
+import './App.css';
 
 function App() {
-  const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
-  const [confirmPassword, setConfirmPassword] = useState('')
-  const [phoneNumber, setPhoneNumber] = useState('')
-  const [isLoading, setIsLoading] = useState(false)
-  const [showForm, setShowForm] = useState(false)
-  const [isLoginView, setIsLoginView] = useState(true)
+  const [showSplash, setShowSplash] = useState(true);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [phoneNumber, setPhoneNumber] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [showForm, setShowForm] = useState(false);
+  const [isLoginView, setIsLoginView] = useState(true);
 
-  // Check if email contains @ symbol for verification icon
-  const isEmailValid = email.includes('@')
+  const isEmailValid = email.includes('@');
 
   useEffect(() => {
-    // Trigger form animation after component mounts
-    setTimeout(() => setShowForm(true), 300)
-  }, [])
+    if (!showSplash) {
+      setTimeout(() => setShowForm(true), 100);
+    }
+  }, [showSplash]);
+
+  const handleLogin = () => {
+    setShowSplash(false);
+    setIsLoginView(true);
+  };
+
+  const handleGetStarted = () => {
+    setShowSplash(false);
+    setIsLoginView(false);
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    setIsLoading(true)
-    // Simulate API call
-    setTimeout(() => setIsLoading(false), 2000)
-  }
+    e.preventDefault();
+    setIsLoading(true);
+    setTimeout(() => setIsLoading(false), 2000);
+  };
 
   const switchView = (newView: boolean) => {
-    // Only clear state and switch if the view is actually changing
     if (isLoginView !== newView) {
       setIsLoginView(newView);
       setEmail('');
@@ -36,19 +46,18 @@ function App() {
     }
   };
 
+  if (showSplash) {
+    return <SplashScreen onLogin={handleLogin} onGetStarted={handleGetStarted} />;
+  }
+
   return (
     <div className="app">
-      {/* Background with animated gradient */}
       <div className="background-gradient"></div>
-      
-      {/* Animated particles */}
       <div className="particles">
         {[...Array(20)].map((_, i) => (
           <div key={i} className={`particle particle-${i}`}></div>
         ))}
       </div>
-
-      {/* Centered Login Card */}
       <div className={`login-section ${showForm ? 'animate-in' : ''}`}>
         <div className="login-card">
           <div className="tab-switcher">
@@ -65,7 +74,6 @@ function App() {
               Sign Up
             </button>
           </div>
-
           <div className="card-header">
             <h1 className="welcome-title">{isLoginView ? 'Welcome Back' : 'Create Account'}</h1>
             <p className="subtitle">Turning Denials Into Approvals</p>

--- a/Kuve-AKU-1/src/SplashScreen.css
+++ b/Kuve-AKU-1/src/SplashScreen.css
@@ -1,0 +1,109 @@
+.splash-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  background-color: #f0f2f5;
+  padding: 20px;
+  box-sizing: border-box;
+}
+
+.splash-card {
+  background-color: white;
+  border-radius: 12px;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.1);
+  padding: 60px;
+  width: 100%;
+  max-width: 800px;
+  position: relative;
+  overflow: hidden;
+}
+
+.splash-content {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  position: relative;
+}
+
+.splash-title {
+  font-size: 28px;
+  font-weight: 600;
+  color: #1c2b36;
+  margin: 0;
+}
+
+.splash-subtitle {
+  font-size: 16px;
+  color: #5a6e7e;
+  margin-top: 8px;
+  margin-bottom: 80px;
+}
+
+.splash-logo {
+  position: absolute;
+  top: 50%;
+  right: 0;
+  transform: translateY(-50%);
+  width: 200px;
+}
+
+.splash-logo img {
+  width: 100%;
+  height: auto;
+}
+
+.splash-buttons {
+  display: flex;
+  gap: 12px;
+  margin-top: auto;
+}
+
+.splash-login-btn,
+.splash-start-btn {
+  padding: 12px 24px;
+  border-radius: 8px;
+  font-size: 16px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  border: 1px solid #d0d5dd;
+}
+
+.splash-login-btn {
+  background-color: white;
+  color: #344054;
+}
+
+.splash-login-btn:hover {
+  background-color: #f9fafb;
+}
+
+.splash-start-btn {
+  background-color: #0044cc;
+  color: white;
+  border-color: #0044cc;
+}
+
+.splash-start-btn:hover {
+  background-color: #003399;
+}
+
+.splash-footer {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  max-width: 800px;
+  margin-top: 20px;
+  font-size: 12px;
+  color: #888;
+}
+
+.version {
+  font-weight: 500;
+}
+
+.copyright {
+  font-weight: 500;
+}

--- a/Kuve-AKU-1/src/SplashScreen.tsx
+++ b/Kuve-AKU-1/src/SplashScreen.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import './SplashScreen.css';
+
+interface SplashScreenProps {
+  onLogin: () => void;
+  onGetStarted: () => void;
+}
+
+const SplashScreen: React.FC<SplashScreenProps> = ({ onLogin, onGetStarted }) => {
+  return (
+    <div className="splash-container">
+      <div className="splash-card">
+        <div className="splash-content">
+          <h1 className="splash-title">Welcome to akuvera</h1>
+          <p className="splash-subtitle">Turning Denials Into Approvals</p>
+          <div className="splash-logo">
+            <img src="/akuvera-logo.png" alt="Akuvera Logo" />
+          </div>
+          <div className="splash-buttons">
+            <button className="splash-login-btn" onClick={onLogin}>
+              Login
+            </button>
+            <button className="splash-start-btn" onClick={onGetStarted}>
+              Get Started
+            </button>
+          </div>
+        </div>
+      </div>
+      <div className="splash-footer">
+        <span className="version">v1.0.0</span>
+        <span className="copyright">© 2025 Akuvera. All rights reserved.</span>
+      </div>
+    </div>
+  );
+};
+
+export default SplashScreen;

--- a/Kuve-AKU-1/src/index.css
+++ b/Kuve-AKU-1/src/index.css
@@ -5,7 +5,6 @@
 
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -57,7 +56,6 @@ button:focus-visible {
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;
-    background-color: #ffffff;
   }
   a:hover {
     color: #747bff;

--- a/dev_server.log
+++ b/dev_server.log
@@ -1,3 +1,0 @@
-
-> vite-react-app@0.0.0 dev
-> vite

--- a/jules-scratch/verification/verify_splash_screen.py
+++ b/jules-scratch/verification/verify_splash_screen.py
@@ -1,0 +1,38 @@
+from playwright.sync_api import sync_playwright, expect
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    # Inject CSS to disable animations
+    page.add_init_script("""
+        const style = document.createElement('style');
+        style.innerHTML = `
+            *, *::before, *::after {
+                animation-duration: 0s !important;
+                transition-duration: 0s !important;
+            }
+        `;
+        document.head.appendChild(style);
+    """)
+
+    try:
+        page.goto("http://localhost:5173", timeout=60000)
+
+        # Wait for the splash screen to be visible
+        expect(page.locator(".splash-container")).to_be_visible(timeout=30000)
+
+        # Take a screenshot
+        page.screenshot(path="jules-scratch/verification/verification.png")
+
+        print("Screenshot taken successfully.")
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+    finally:
+        browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)


### PR DESCRIPTION
This commit introduces a new splash screen that is displayed when the application first loads. The splash screen includes a welcome message, a subtitle, and buttons to navigate to the login and sign-up views.

The implementation includes:
- A new `SplashScreen` component and its corresponding stylesheet.
- State management in `App.tsx` to conditionally render the splash screen.
- Scoped styling to prevent visual conflicts between the splash screen and the main application.

Note: The `akuvera-logo.png` is not included in this commit due to file system access issues. The splash screen is designed to display the logo, but the image asset is currently missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a splash screen with title, subtitle, logo, and “Log In” / “Get Started” actions, transitioning into login or signup.
- Style
  - Added dedicated splash screen styling for a centered, card-based layout with responsive behavior.
  - Applied animated background gradient to the page body for a consistent, full-page effect.
  - Removed default background colors to align with the new gradient-driven theme.
- Tests
  - Added an automated visual verification script to confirm the splash screen renders correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->