### PR TITLE
feat: Implement full-height panel layout and splash screen

### DIFF
--- a/Kuve-AKU-1/src/App.css
+++ b/Kuve-AKU-1/src/App.css
@@ -10,13 +10,9 @@ body {
 }
 
 .app {
-  min-height: 100vh;
-  position: relative;
   display: flex;
-  align-items: center;
-  justify-content: center;
-  overflow-y: auto; /* Enable vertical scrolling */
-  padding: 2rem 0 80px; /* Add vertical padding and space for footer */
+  flex-direction: column;
+  min-height: 100vh;
   background-color: white;
 }
 
@@ -83,20 +79,22 @@ body {
 
 .main-content {
   display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 2rem;
-  width: 100%;
-  max-width: 1200px;
-  padding: 2rem;
-  background-color: rgb(195, 207, 226);
+  flex: 1;
+  align-items: stretch;
 }
 
 .login-section {
-  flex: 1;
-  max-width: 500px;
+  width: 450px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 3rem;
+  border-right: 1px solid #e0e0e0;
+  box-shadow: 4px 0 15px -5px rgba(0, 0, 0, 0.1);
+  z-index: 1;
   opacity: 0;
-  transform: translateY(50px);
+  transform: translateX(-50px);
   transition: all 0.8s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
@@ -105,9 +103,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  opacity: 0;
-  transform: translateY(50px);
-  animation: fadeIn 1s ease-out 0.5s both;
+  background-color: rgb(195, 207, 226);
 }
 
 .logo-section img {
@@ -117,23 +113,11 @@ body {
 
 .login-section.animate-in {
   opacity: 1;
-  transform: translateY(0);
+  transform: translateX(0);
 }
 
 .login-card {
-  background: rgba(255, 255, 255, 0.95);
-  backdrop-filter: blur(10px);
-  border-radius: 20px;
-  padding: 2.5rem; /* Adjusted padding */
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
   width: 100%;
-  animation: cardFloat 6s ease-in-out infinite;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-}
-
-@keyframes cardFloat {
-  0%, 100% { transform: translateY(0px); }
-  50% { transform: translateY(-5px); }
 }
 
 /* Tab Switcher */
@@ -450,8 +434,15 @@ body {
     flex-direction: column;
   }
 
+  .login-section {
+    width: 100%;
+    border-right: none;
+    box-shadow: none;
+    padding: 2rem;
+  }
+
   .logo-section {
-    display: none; /* Hide logo on smaller screens to save space */
+    display: none;
   }
 }
 

--- a/jules-scratch/verification/verify_panel_layout.py
+++ b/jules-scratch/verification/verify_panel_layout.py
@@ -1,0 +1,44 @@
+from playwright.sync_api import sync_playwright, expect
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    # Inject CSS to disable animations
+    page.add_init_script("""
+        const style = document.createElement('style');
+        style.innerHTML = `
+            *, *::before, *::after {
+                animation-duration: 0s !important;
+                transition-duration: 0s !important;
+            }
+        `;
+        document.head.appendChild(style);
+    """)
+
+    try:
+        page.goto("http://localhost:5173", timeout=60000)
+
+        # Explicitly wait for the splash screen container
+        page.wait_for_selector(".splash-container", timeout=15000)
+
+        # Click "Login" on the splash screen
+        page.locator("button.splash-login-btn").click()
+
+        # Wait for the login section to be visible
+        expect(page.locator(".login-section")).to_be_visible(timeout=10000)
+
+        # Take a screenshot
+        page.screenshot(path="jules-scratch/verification/panel_layout_verification.png")
+
+        print("Screenshot taken successfully.")
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+    finally:
+        browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)


### PR DESCRIPTION
This commit introduces a new splash screen, makes the footer sticky, and redesigns the login page to use a full-height vertical panel layout.

Key changes include:
- A new `SplashScreen` component that serves as the initial landing page.
- The footer is now `position: fixed` to ensure it is always visible at the bottom of the viewport.
- The main content area has been updated to a full-height layout where the login form is in a vertical panel on the left, and the Akuvera logo is displayed on the right.
- The layout is responsive and will stack vertically on smaller screens, with the logo hidden to save space.

Note: The `akuvera-logo.png` is referenced in the code but may still be missing from the project assets due to file system limitations. The layout is designed to accommodate it once available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * None

* Style
  * Overhauled app layout for clearer structure and full-height pages.
  * Simplified login panel with cleaner visuals and consistent spacing.
  * Removed heavy entrance animations for a snappier, more stable experience.
  * Improved responsiveness: fixed-width login panel on desktop; full-width on smaller screens.

* Refactor
  * Streamlined component alignment and sizing for consistency across breakpoints.

* Tests
  * Added automated UI verification to capture and validate the login panel layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->