### PR TITLE
feat: Implement splash screen, panel layout, and styling

### DIFF
--- a/Kuve-AKU-1/src/App.css
+++ b/Kuve-AKU-1/src/App.css
@@ -84,8 +84,7 @@ body {
 }
 
 .login-section {
-  width: 450px;
-  flex-shrink: 0;
+  width: 45%;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -99,7 +98,7 @@ body {
 }
 
 .logo-section {
-  flex: 1;
+  width: 55%;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/jules-scratch/verification/verify_column_widths.py
+++ b/jules-scratch/verification/verify_column_widths.py
@@ -1,0 +1,44 @@
+from playwright.sync_api import sync_playwright, expect
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    # Inject CSS to disable animations
+    page.add_init_script("""
+        const style = document.createElement('style');
+        style.innerHTML = `
+            *, *::before, *::after {
+                animation-duration: 0s !important;
+                transition-duration: 0s !important;
+            }
+        `;
+        document.head.appendChild(style);
+    """)
+
+    try:
+        page.goto("http://localhost:5173", timeout=60000)
+
+        # Explicitly wait for the splash screen container
+        page.wait_for_selector(".splash-container", timeout=15000)
+
+        # Click "Login" on the splash screen
+        page.locator("button.splash-login-btn").click()
+
+        # Wait for the login section to be visible
+        expect(page.locator(".login-section")).to_be_visible(timeout=10000)
+
+        # Take a screenshot
+        page.screenshot(path="jules-scratch/verification/column_widths_verification.png")
+
+        print("Screenshot taken successfully.")
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+    finally:
+        browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)


### PR DESCRIPTION
This commit introduces a new splash screen and a redesigned login page with a full-height vertical panel layout and updated styling.

Key changes include:
- A new `SplashScreen` component that serves as the initial landing page.
- The main application layout is now a full-height, two-column design.
- The login form is in a vertical panel on the left, taking up 45% of the screen width.
- The logo is displayed in a panel on the right, taking up the remaining 55% of the screen.
- The background colors of the main application and content areas have been updated.
- The footer is now `position: fixed` to ensure it is always visible.

Note: The `akuvera-logo.png` is referenced in the code but may still be missing from the project assets due to file system limitations. The layout is designed to accommodate it once available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated login layout proportions: login section now spans 45% of the width and logo section 55%, delivering a more balanced, consistent presentation across screen sizes and preventing unexpected shrinking.

- Tests
  - Added an automated browser-based verification that navigates to the app, proceeds to the login view, validates column visibility and proportions, and captures a screenshot to confirm layout accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->