### PR TITLE
feat: Implement splash screen and redesign login page

### DIFF
--- a/Kuve-AKU-1/src/SplashScreen.css
+++ b/Kuve-AKU-1/src/SplashScreen.css
@@ -18,6 +18,14 @@
   max-width: 800px;
   position: relative;
   overflow: hidden;
+  opacity: 0;
+  transform: translateY(50px);
+  transition: all 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.splash-card.animate-in {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .splash-content {

--- a/Kuve-AKU-1/src/SplashScreen.tsx
+++ b/Kuve-AKU-1/src/SplashScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import './SplashScreen.css';
 
 interface SplashScreenProps {
@@ -7,9 +7,15 @@ interface SplashScreenProps {
 }
 
 const SplashScreen: React.FC<SplashScreenProps> = ({ onLogin, onGetStarted }) => {
+  const [showCard, setShowCard] = useState(false);
+
+  useEffect(() => {
+    setTimeout(() => setShowCard(true), 100);
+  }, []);
+
   return (
     <div className="splash-container">
-      <div className="splash-card">
+      <div className={`splash-card ${showCard ? 'animate-in' : ''}`}>
         <div className="splash-content">
           <h1 className="splash-title">Welcome to akuvera</h1>
           <p className="splash-subtitle">Turning Denials Into Approvals</p>

--- a/jules-scratch/verification/verify_splash_animation.py
+++ b/jules-scratch/verification/verify_splash_animation.py
@@ -1,0 +1,38 @@
+from playwright.sync_api import sync_playwright, expect
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    # Inject CSS to make transitions instant for stable screenshots
+    page.add_init_script("""
+        const style = document.createElement('style');
+        style.innerHTML = `
+            *, *::before, *::after {
+                transition-duration: 0s !important;
+            }
+        `;
+        document.head.appendChild(style);
+    """)
+
+    try:
+        page.goto("http://localhost:5173", timeout=60000)
+
+        # Wait for the splash card to get the 'animate-in' class
+        splash_card = page.locator(".splash-card")
+        expect(splash_card).to_have_class("splash-card animate-in", timeout=10000)
+
+        # Take a screenshot
+        page.screenshot(path="jules-scratch/verification/splash_animation_verification.png")
+
+        print("Screenshot taken successfully.")
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+    finally:
+        browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)


### PR DESCRIPTION
This commit introduces a new splash screen and a completely redesigned login page with a full-height vertical panel layout, updated styling, and new animations.

Key changes include:
- A new `SplashScreen` component that serves as the initial landing page, with animations matching the main content area.
- The main application layout is now a full-height, two-column design.
- The login form is in a vertical panel on the left, taking up 45% of the screen width.
- The logo is displayed in a panel on the right, taking up the remaining 55% of the screen.
- The background colors of the main application and content areas have been updated as requested.
- The footer is now `position: fixed` to ensure it is always visible.

Note: The `akuvera-logo.png` is referenced in the code but may still be missing from the project assets due to file system limitations. The layout is designed to accommodate it once available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a smooth entrance animation to the splash card, fading in and sliding into view for a more polished first impression.
  - Splash screen now auto-reveals shortly after load for a seamless experience.

- Tests
  - Introduced an automated check to verify the splash animation appears correctly and remains visually consistent across runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->