### PR TITLE
Refactor splash screen to a full-height side-panel layout

### DIFF
--- a/Kuve-AKU-1/src/SplashScreen.css
+++ b/Kuve-AKU-1/src/SplashScreen.css
@@ -26,7 +26,13 @@
   flex-grow: 1; /* Takes remaining space */
   display: flex;
   align-items: center;
-  justify-content: center;
+  /* justify-content: center; /* Removed for alternative centering */
+}
+
+.splash-logo {
+  width: 250px;
+  text-align: center;
+  margin: 0 auto; /* Added for robust horizontal centering */
 }
 
 .splash-title {


### PR DESCRIPTION
- Updated `SplashScreen.css` to implement a full-height, two-column layout.
- The left `splash-card` now takes up 45% of the width, stretches to the full viewport height, and features a vertical divider on its right edge.
- The background color of the main container has been updated to `rgb(195, 207, 226)`.
- Refactored `SplashScreen.tsx` to separate the logo into a `main-content` area, which occupies the remaining screen space.
- Removed unused animation logic from the component.
- Centered the logo horizontally within its container using `margin: 0 auto`.
- Verified the final layout with a Playwright screenshot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Fixed inconsistent horizontal centering of the splash logo across devices by applying a dedicated centering style.
  - Prevented the main content area from unintentionally forcing centered layout.

- Style
  - Refined splash screen layout for improved visual balance.
  - Introduced a reusable splash logo style to ensure consistent width and alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->