### PR TITLE
Refactor splash screen to a full-height side-panel layout

### DIFF
--- a/Kuve-AKU-1/src/SplashScreen.css
+++ b/Kuve-AKU-1/src/SplashScreen.css
@@ -23,16 +23,17 @@
 }
 
 .main-content {
-  flex-grow: 1; /* Takes remaining space */
-  display: flex;
-  align-items: center;
-  /* justify-content: center; /* Removed for alternative centering */
+  flex-grow: 1;
+  position: relative;
 }
 
 .splash-logo {
   width: 250px;
   text-align: center;
-  margin: 0 auto; /* Added for robust horizontal centering */
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 
 .splash-title {


### PR DESCRIPTION
- Updated `SplashScreen.css` to implement a full-height, two-column layout.
- The left `splash-card` now takes up 45% of the width, stretches to the full viewport height, and features a vertical divider on its right edge.
- The background color of the main container has been updated to `rgb(195, 207, 226)`.
- Refactored `SplashScreen.tsx` to separate the logo into a `main-content` area, which occupies the remaining screen space.
- Removed unused animation logic from the component.
- Centered the logo both vertically and horizontally within its container using absolute positioning.
- Verified the final layout with a Playwright screenshot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated splash screen layout to ensure the logo is precisely centered within the main content area.
  * Improved visual consistency and balance across different screen sizes.

* **Bug Fixes**
  * Resolved inconsistent logo alignment on the splash screen across devices and orientations.
  * Eliminated layout shifts by stabilizing the centering behavior during load.

* **Refactor**
  * Simplified centering approach to improve maintainability and predictability of splash screen layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->