### PR TITLE
Refactor splash screen with full-height layout and footer updates

### DIFF
--- a/Kuve-AKU-1/src/SplashScreen.css
+++ b/Kuve-AKU-1/src/SplashScreen.css
@@ -50,11 +50,6 @@
   margin-bottom: 3rem;
 }
 
-.splash-logo {
-  width: 250px;
-  text-align: center;
-}
-
 .splash-logo img {
   width: 100%;
   height: auto;
@@ -100,11 +95,11 @@
 
 .splash-footer {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-start; /* Align version to the left */
   width: 100%;
   font-size: 12px;
   color: #888;
-  padding-top: 2rem; /* Add some space above the footer */
+  padding-top: 2rem;
 }
 
 .version {
@@ -119,7 +114,9 @@
   position: absolute;
   bottom: 2rem;
   width: 100%;
-  text-align: center;
+  text-align: right; /* Align copyright to the right */
   color: #5a6e7e;
   font-size: 12px;
+  padding-right: 2rem;
+  box-sizing: border-box;
 }


### PR DESCRIPTION
- Implemented a full-height, two-column layout with a white side panel on the left (45% width).
- Updated the main content area background color to `rgb(195, 207, 226)`.
- Centered the logo both vertically and horizontally in the main content area using absolute positioning.
- Relocated the copyright notice to the bottom of the main content area.
- Aligned the version number to the left within the side panel footer.
- Aligned the copyright notice to the right within the main content footer.
- All layout changes have been verified with Playwright screenshots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refreshed splash screen layout with a cleaner look by removing the logo.
  * Updated footer alignment for a more consistent and balanced presentation.
  * Improved version display: now right-aligned with added padding for better readability.
  * Streamlined spacing and visual details for a tidier first-run experience.
  * Minor visual polish to enhance clarity and consistency across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->