### PR TITLE
Feat: Add Back button and refactor splash/login layout

### DIFF
--- a/Kuve-AKU-1/src/SplashScreen.css
+++ b/Kuve-AKU-1/src/SplashScreen.css
@@ -93,13 +93,18 @@
   background-color: #003399;
 }
 
-.splash-footer {
-  display: flex;
-  justify-content: flex-start; /* Align version to the left */
+.page-footer {
+  position: fixed;
+  bottom: 0;
+  left: 0;
   width: 100%;
+  display: flex;
+  justify-content: space-between;
+  padding: 1rem 2rem;
+  box-sizing: border-box;
   font-size: 12px;
-  color: #888;
-  padding-top: 2rem;
+  color: #5a6e7e;
+  z-index: 10;
 }
 
 .version {
@@ -108,15 +113,4 @@
 
 .copyright {
   font-weight: 500;
-}
-
-.main-footer {
-  position: absolute;
-  bottom: 2rem;
-  width: 100%;
-  text-align: right; /* Align copyright to the right */
-  color: #5a6e7e;
-  font-size: 12px;
-  padding-right: 2rem;
-  box-sizing: border-box;
 }

--- a/Kuve-AKU-1/src/SplashScreen.tsx
+++ b/Kuve-AKU-1/src/SplashScreen.tsx
@@ -24,17 +24,15 @@ const SplashScreen: React.FC<SplashScreenProps> = ({ onLogin, onGetStarted }) =>
             </button>
           </div>
         </div>
-        <div className="splash-footer">
-          <span className="version">v1.0.0</span>
-        </div>
       </div>
       <div className="main-content">
         <div className="splash-logo">
           <img src="/akuvera-logo.png" alt="Akuvera Logo" />
         </div>
-        <div className="main-footer">
-          <span className="copyright">© 2025 Akuvera. All rights reserved.</span>
-        </div>
+      </div>
+      <div className="page-footer">
+        <span className="version">v1.0.0</span>
+        <span className="copyright">© 2025 Akuvera. All rights reserved.</span>
       </div>
     </div>
   );


### PR DESCRIPTION
- Adds a 'Back' button to the login and sign-up forms to allow users to return to the initial splash screen.
- Implements a `handleGoBack` function in `App.tsx` to manage the view state transition.
- Styles the new 'Back' button in `App.css` for a distinct appearance.

This commit also includes a significant refactoring of the splash screen and login page layouts based on previous user requests:

- The splash screen is now a full-height, two-column layout with a white side panel and a main content area.
- The logo is centered vertically and horizontally in the main content area.
- A single, page-wide footer is fixed to the bottom of the screen, with the version number on the left and the copyright notice on the right.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Replaced split footers with a single, full-width page footer fixed to the bottom. Uses a balanced, space-between layout with improved spacing, readability, and consistent color. Footer remains visible across screen sizes.
- Refactor
  - Consolidated version and copyright into one footer section, simplifying the layout and reducing visual clutter while providing a clearer hierarchy for footer information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->