### PR TITLE
feat: Extend password strength indicator to all password fields

### DIFF
--- a/Kuve-AKU-1/src/App.tsx
+++ b/Kuve-AKU-1/src/App.tsx
@@ -17,11 +17,26 @@ function App() {
     digit: false,
     specialChar: false,
   });
+  const [confirmPasswordCriteria, setConfirmPasswordCriteria] = useState({
+    uppercase: false,
+    lowercase: false,
+    digit: false,
+    specialChar: false,
+  });
 
   const isEmailValid = email.includes('@');
 
   const validatePassword = (password: string) => {
     setPasswordCriteria({
+      uppercase: /[A-Z]/.test(password),
+      lowercase: /[a-z]/.test(password),
+      digit: /\d/.test(password),
+      specialChar: /[!@#$%^&*(),.?":{}|<>]/.test(password),
+    });
+  };
+
+  const validateConfirmPassword = (password: string) => {
+    setConfirmPasswordCriteria({
       uppercase: /[A-Z]/.test(password),
       lowercase: /[a-z]/.test(password),
       digit: /\d/.test(password),
@@ -159,7 +174,7 @@ function App() {
                 className="form-input"
                 required
               />
-               {!isLoginView && password.length > 0 && (
+               {password.length > 0 && (
                 <div className="password-strength-indicator">
                   <div className={`criterion ${passwordCriteria.uppercase ? 'verified' : ''}`}>
                     <span className="criterion-icon"></span> Upper Case
@@ -184,11 +199,30 @@ function App() {
                   type="password"
                   id="confirmPassword"
                   value={confirmPassword}
-                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  onChange={(e) => {
+                    setConfirmPassword(e.target.value);
+                    validateConfirmPassword(e.target.value);
+                  }}
                   placeholder="••••••••••"
                   className="form-input"
                   required
                 />
+                {confirmPassword.length > 0 && (
+                  <div className="password-strength-indicator">
+                    <div className={`criterion ${confirmPasswordCriteria.uppercase ? 'verified' : ''}`}>
+                      <span className="criterion-icon"></span> Upper Case
+                    </div>
+                    <div className={`criterion ${confirmPasswordCriteria.lowercase ? 'verified' : ''}`}>
+                      <span className="criterion-icon"></span> Lower Case
+                    </div>
+                    <div className={`criterion ${confirmPasswordCriteria.digit ? 'verified' : ''}`}>
+                      <span className="criterion-icon"></span> Digit
+                    </div>
+                    <div className={`criterion ${confirmPasswordCriteria.specialChar ? 'verified' : ''}`}>
+                      <span className="criterion-icon"></span> Special Character
+                    </div>
+                  </div>
+                )}
               </div>
             )}
 


### PR DESCRIPTION
This commit extends the password strength indicator to all password-related input fields, including the login password and the sign-up 'Confirm Password' field.

- The indicator is now displayed on the login page's password field.
- The indicator is also displayed on the sign-up page's 'Confirm Password' field.
- This ensures a consistent user experience across the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added confirm password validation with real-time criteria (uppercase, lowercase, number, special character).
  - Introduced a confirm password strength indicator that appears as users type.
  - Made the main password strength indicator always show when a password is entered, for consistent visibility.
  - Instant visual feedback updates for both fields as input changes.
  - Parallel indicators help users meet requirements and reduce errors during sign-up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->