### PR TITLE
feat: Redesign splash screen with a centered card layout

### DIFF
--- a/Kuve-AKU-1/src/SplashScreen.css
+++ b/Kuve-AKU-1/src/SplashScreen.css
@@ -1,116 +1,115 @@
+body, html {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  font-family: sans-serif;
+}
+
 .splash-container {
   display: flex;
-  min-height: 100vh;
-  background-color: rgb(195, 207, 226);
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100vh;
+  background-color: #F2F4F5;
 }
 
 .splash-card {
-  width: 45%;
-  background-color: white;
+  width: 800px;
+  height: 600px;
+  background-color: #FFFFFF;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
-  padding: 4rem;
-  box-sizing: border-box;
-  border-right: 1px solid #dde1e6;
-  box-shadow: 3px 0 15px -2px rgba(0, 0, 0, 0.1);
-}
-
-.splash-content {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  flex-grow: 1; /* Pushes footer to the bottom */
-}
-
-.main-content {
-  flex-grow: 1;
-  position: relative;
-}
-
-.splash-logo {
-  width: 250px;
+  align-items: center;
   text-align: center;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  box-sizing: border-box;
+  padding: 20px;
 }
 
 .splash-title {
-  font-size: 28px;
-  font-weight: 600;
-  color: #1c2b36;
-  margin: 0;
+  font-size: 24px;
+  font-weight: bold;
+  color: #333333;
+  margin-top: 40px;
 }
 
 .splash-subtitle {
   font-size: 16px;
-  color: #5a6e7e;
-  margin-top: 8px;
-  margin-bottom: 3rem;
+  color: #666666;
+  margin-top: 10px;
 }
 
-.splash-logo img {
-  width: 100%;
-  height: auto;
+.splash-logo {
+  margin-top: 20px;
+}
+
+.splash-tagline {
+  font-size: 12px;
+  color: #666666;
+  margin-top: 10px;
 }
 
 .splash-buttons {
+  margin-top: auto;
+  margin-bottom: 20px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  width: 220px;
+  align-items: center;
+  gap: 10px;
 }
 
 .splash-login-btn,
 .splash-start-btn {
-  padding: 12px 24px;
-  border-radius: 8px;
   font-size: 16px;
-  font-weight: 500;
+  font-weight: bold;
+  padding: 10px;
+  width: 200px;
   cursor: pointer;
-  transition: all 0.3s ease;
-  border: 1px solid #d0d5dd;
-  text-align: center;
+  border-radius: 5px;
 }
 
 .splash-login-btn {
-  background-color: white;
-  color: #344054;
-}
-
-.splash-login-btn:hover {
-  background-color: #f9fafb;
+  background-color: transparent;
+  border: 1px solid #0056b3;
+  color: #0056b3;
 }
 
 .splash-start-btn {
-  background-color: #0044cc;
+  background-color: #0056b3;
+  border: none;
   color: white;
-  border-color: #0044cc;
+  margin-bottom: 10px;
 }
 
-.splash-start-btn:hover {
-  background-color: #003399;
-}
-
-.page-footer {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  display: flex;
-  justify-content: space-between;
-  padding: 1rem 2rem;
-  box-sizing: border-box;
+.splash-footer {
   font-size: 12px;
-  color: #5a6e7e;
-  z-index: 10;
+  color: #999999;
+  margin-bottom: 40px;
 }
 
-.version {
-  font-weight: 500;
+@media (max-width: 850px) {
+  .splash-card {
+    width: 90%;
+    height: auto;
+    padding: 20px;
+  }
 }
 
-.copyright {
-  font-weight: 500;
+@media (max-width: 600px) {
+  .splash-card {
+    width: 100%;
+    height: 100%;
+    border-radius: 0;
+    box-shadow: none;
+  }
+
+  .splash-title {
+    margin-top: 20px;
+  }
+
+  .splash-buttons {
+    margin-top: 40px;
+  }
 }

--- a/Kuve-AKU-1/src/SplashScreen.tsx
+++ b/Kuve-AKU-1/src/SplashScreen.tsx
@@ -10,29 +10,23 @@ const SplashScreen: React.FC<SplashScreenProps> = ({ onLogin, onGetStarted }) =>
   return (
     <div className="splash-container">
       <div className="splash-card">
-        <div className="splash-content">
-          <div>
-            <h1 className="splash-title">Welcome to akuvera</h1>
-            <p className="splash-subtitle">Turning Denials Into Approvals</p>
-          </div>
-          <div className="splash-buttons">
-            <button className="splash-login-btn" onClick={onLogin}>
-              Login
-            </button>
-            <button className="splash-start-btn" onClick={onGetStarted}>
-              Get Started
-            </button>
-          </div>
-        </div>
-      </div>
-      <div className="main-content">
+        <h1 className="splash-title">Welcome to akuvera</h1>
+        <p className="splash-subtitle">Turning Denials Into Approvals</p>
         <div className="splash-logo">
-          <img src="/akuvera-logo.png" alt="Akuvera Logo" />
+          {/* <img src="/akuvera-logo.png" alt="Akuvera Logo" /> */}
+          <p className="splash-tagline">Delivers clarity and truth in denial logic</p>
         </div>
-      </div>
-      <div className="page-footer">
-        <span className="version">v1.0.0</span>
-        <span className="copyright">© 2025 Akuvera. All rights reserved.</span>
+        <div className="splash-buttons">
+          <button className="splash-login-btn" onClick={onLogin}>
+            Login
+          </button>
+          <button className="splash-start-btn" onClick={onGetStarted}>
+            Get Started
+          </button>
+        </div>
+        <div className="splash-footer">
+          <p>v1.0.0 © 2025 Akuvera. All rights reserved.</p>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Implements a new design for the splash screen based on the user's specifications.

The new layout features a single, centered 800x600px card with updated typography, button styles, and a consistent footer. The changes have been verified via a Playwright script and a screenshot.

The logo has been temporarily commented out due to a missing asset file, but the structure is in place to easily add it back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a centered, card-based splash screen with a tagline.
  * Added a footer displaying version and copyright.
  * Reordered content so buttons appear after the logo/tagline.

* **Style**
  * Applied full-viewport layout with updated typography and colors.
  * Revamped button styling with clearer hover/active states and fixed widths.
  * Implemented responsive behavior for smaller screens (card size, padding, spacing).
  * Simplified layout by removing legacy positioning and adopting consistent spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->