### PR TITLE
fix: Remove fade-in animation to ensure card visibility

### DIFF
--- a/Kuve-AKU-1/src/App.css
+++ b/Kuve-AKU-1/src/App.css
@@ -85,14 +85,7 @@ body, html {
   border-radius: 12px;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
   overflow: hidden;
-  opacity: 0;
-  transform: translateY(20px) scale(0.98);
-  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
-}
-
-.splash-card.animate-in {
-  opacity: 1;
-  transform: translateY(0) scale(1);
+  /* Removed animation properties to fix visibility issue */
 }
 
 /* Left & Right Columns (from SplashScreen.css) */


### PR DESCRIPTION
This commit removes the opacity and transform animations from the `.splash-card` class in `App.css`.

The animation was causing the card and its content to be semi-transparent or invisible on load, making it difficult for the user to see the content. By removing these properties, the card is now always fully visible, resolving the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the splash card entry animation, so content appears instantly without fade/slide effects.
  * Improves perceived load time and reduces visual jank on initial view.
  * Provides a calmer, reduced-motion experience for users sensitive to animations.
  * Enhances layout stability across devices, including low-power or constrained environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->