### PR TITLE
feat: Display password strength indicator on login tab

### DIFF
--- a/Kuve-AKU-1/src/App.tsx
+++ b/Kuve-AKU-1/src/App.tsx
@@ -182,7 +182,7 @@ function App() {
                     className="form-input"
                     required
                   />
-                  {password.length > 0 && !isLoginView && (
+                  {password.length > 0 && (
                     <div className="password-strength-indicator">
                       <div className={`criterion ${passwordCriteria.uppercase ? 'verified' : ''}`}><span className="criterion-icon"></span> Upper Case</div>
                       <div className={`criterion ${passwordCriteria.lowercase ? 'verified' : ''}`}><span className="criterion-icon"></span> Lower Case</div>


### PR DESCRIPTION
This commit updates the conditional rendering logic in `App.tsx` to show the `password-strength-indicator` on the login view.

Previously, the indicator was only shown on the sign-up form. This change removes the `!isLoginView` condition, allowing the indicator to be displayed whenever a user types in the password field on either the login or sign-up tabs, providing consistent user feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Password strength indicator now appears in both login and signup views whenever you enter a password, offering immediate feedback on password robustness.
  * Provides a consistent experience across authentication screens and helps users choose stronger passwords more easily.
  * No changes to authentication behavior or error handling; this is a UI enhancement for better clarity and guidance during password entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->