### PR TITLE
feat: Update form styling for inputs and password indicator

### DIFF
--- a/Kuve-AKU-1/src/App.css
+++ b/Kuve-AKU-1/src/App.css
@@ -265,53 +265,48 @@ body, html {
 
 /* Password Strength */
 .password-strength-indicator {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 0.5rem;
-  padding: 0.75rem;
-  background-color: #f8f9fa;
-  border-radius: 6px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
   margin-top: 0.75rem;
-  font-size: 0.8rem;
+  font-size: 0.75rem;
 }
 
 .criterion {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  color: #6c757d;
-  transition: color 0.3s ease;
+  gap: 0.4rem;
+  color: #888;
 }
 
 .criterion.verified {
-  color: #212529;
-  font-weight: 500;
+  color: #000;
 }
 
 .criterion-icon {
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  border: 1.5px solid #ced4da;
-  position: relative;
-  transition: all 0.3s ease;
+  display: none; /* Hide icon by default */
 }
 
 .criterion.verified .criterion-icon {
+  display: inline-block; /* Show icon only when verified */
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
   background-color: #28a745;
-  border-color: #28a745;
+  border: 1.5px solid #28a745;
+  position: relative;
 }
 
 .criterion.verified .criterion-icon::after {
   content: '';
   position: absolute;
-  top: 50%;
+  top: 45%;
   left: 50%;
-  width: 4px;
-  height: 8px;
+  width: 3px;
+  height: 6px;
   border: solid white;
-  border-width: 0 2px 2px 0;
-  transform: translate(-50%, -60%) rotate(45deg);
+  border-width: 0 1.5px 1.5px 0;
+  transform: translate(-50%, -50%) rotate(45deg);
 }
 
 /* Form Actions */


### PR DESCRIPTION
This commit introduces several visual enhancements to the form elements to improve user experience and align with the provided design.

- **Input Fields:**
  - Set the background color of form inputs to white.
  - Set the input text color to a dark shade (`#333`) for better readability.
  - Set the placeholder text color to grey (`#888`).

- **Password Strength Indicator:**
  - Restyled the indicator to match the provided image.
  - Changed the layout from a grid to a single horizontal row using flexbox.
  - Removed the container's background and padding.
  - Adjusted font and icon sizes for a more compact appearance.
  - Updated colors to use a green checkmark for verified criteria and grey text for unverified criteria.
  - The indicator is now displayed on both the login and sign-up tabs for consistent feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated password strength indicator layout from grid to flexible, wrapping flex for better responsiveness.
  * Tweaked typography and spacing: reduced font size and adjusted gaps for clearer readability.
  * Refined criterion styling with lighter gray text; criterion icon hidden by default and shown when verified.
  * Enhanced verified state: darker text, smaller icon, added bordered circular badge with improved checkmark alignment.
  * General visual polish for consistency and clarity across the indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->