### PR TITLE
refactor: Adjust card dimensions for a wider and shorter layout

### DIFF
--- a/Kuve-AKU-1/src/App.css
+++ b/Kuve-AKU-1/src/App.css
@@ -79,18 +79,12 @@ body, html {
 .splash-card {
   display: flex;
   width: 100%;
-  max-width: 960px;
-  min-height: 600px;
+  max-width: 1200px; /* Increased */
+  min-height: 480px; /* Drastically Reduced */
   background-color: #FFFFFF;
   border-radius: 12px;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
   overflow: hidden;
-  transition: max-width 0.4s ease; /* Smooth transition for width change */
-}
-
-/* Increase width for the sign-up view */
-.splash-card.signup-view {
-  max-width: 1050px;
 }
 
 /* Left & Right Columns (from SplashScreen.css) */


### PR DESCRIPTION
This commit updates the CSS for the `.splash-card` to reshape the main form container.

- Increased the `max-width` to `1200px` to make the card wider.
- Decreased the `min-height` to `480px` to make the card shorter.
- Removed the specific styling for the `signup-view` as the new base style accommodates both login and sign-up views effectively.