### PR TITLE
Run npm install to generate a package-lock.json file.

### DIFF
--- a/npm_output.log
+++ b/npm_output.log
@@ -2,8 +2,10 @@
 > vite-react-app@0.0.0 dev
 > vite
 
+Re-optimizing dependencies because lockfile has changed
+Port 5173 is in use, trying another one...
 
-  VITE v5.4.20  ready in 360 ms
+  VITE v5.4.20  ready in 657 ms
 
-  ➜  Local:   http://localhost:5173/
+  ➜  Local:   http://localhost:5174/
   ➜  Network: use --host to expose


### PR DESCRIPTION
This ensures that dependencies, including 'recharts', are correctly installed, fixing the "Failed to resolve import" error during Vite's import analysis.