### PR TITLE
feat: Implement responsive Claims Management page

### DIFF
--- a/Kuve-AKU-1/src/components/ClaimsManagement.css
+++ b/Kuve-AKU-1/src/components/ClaimsManagement.css
@@ -149,6 +149,7 @@
 .tabs {
   display: flex;
   gap: 0.5rem;
+  flex-wrap: wrap; /* Allow tabs to wrap on smaller screens */
 }
 
 .tab-button {
@@ -275,4 +276,73 @@
   color: #9ca3af;
   font-weight: bold;
   letter-spacing: 0.1rem;
+}
+
+/* --- Responsive Styles --- */
+
+/* Tablet */
+@media (max-width: 1200px) {
+  .claims-stat-cards {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 992px) {
+  .claims-management {
+    padding: 1.5rem;
+  }
+  .claims-table-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+  .table-actions {
+    margin-left: 0;
+    width: 100%;
+    justify-content: flex-start;
+  }
+  .search-bar {
+    flex-grow: 1;
+  }
+  .search-bar input {
+      width: 100%;
+  }
+}
+
+/* Mobile */
+@media (max-width: 768px) {
+  .claims-management .header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+  .claims-management .header-actions {
+      width: 100%;
+  }
+  .claims-management .header-button {
+      flex-grow: 1;
+      justify-content: center;
+  }
+  .claims-stat-cards {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .claims-table-container {
+      padding: 1rem;
+  }
+}
+
+@media (max-width: 576px) {
+    .claims-stat-cards {
+        grid-template-columns: 1fr;
+    }
+    .tabs {
+        gap: 0.25rem;
+    }
+    .tab-button {
+        padding: 0.5rem 0.75rem;
+    }
+    .table-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
 }

--- a/Kuve-AKU-1/src/components/Dashboard.css
+++ b/Kuve-AKU-1/src/components/Dashboard.css
@@ -96,6 +96,12 @@
   flex-direction: column;
 }
 
+@media (max-width: 768px) {
+  .sidebar {
+    display: none;
+  }
+}
+
 .user-name {
   font-weight: 600;
   color: #1F2937;


### PR DESCRIPTION
This commit introduces the "Claims Management" page, which is displayed when the "Claims" navigation item is clicked. The page has been styled to be a pixel-perfect match of the provided design and is fully responsive for tablet and mobile devices.

Key changes include:
- Created a new `ClaimsManagement` component to display the claims data, including status cards and a data table.
- Refactored the `Dashboard` component to act as a view controller, conditionally rendering either the `DashboardOverview` or `ClaimsManagement` component.
- Moved the original dashboard content into a new `DashboardOverview` component to improve code organization.
- Implemented state management in `Dashboard.tsx` to handle the switching between views.
- Added `onClick` handlers to the sidebar navigation to trigger the view change.
- Created and refined dedicated CSS files for each new component to ensure modular and maintainable styling.
- Added media queries to `ClaimsManagement.css` and `Dashboard.css` to ensure the layout adapts correctly to different screen sizes.
- Fixed invalid DOM property warnings in SVG elements by converting attributes to camelCase.
- Corrected layout and overflow issues to ensure the page displays correctly on all devices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced mobile responsiveness for Claims Management: tabs now wrap, stat cards reflow across breakpoints, headers and controls stack on narrow screens, and table actions/search expand to full width for easier use.
  * Dashboard now hides the sidebar on small screens to maximize content space and improve focus.
* **Style**
  * Adjusted spacing and layout behaviors across multiple screen sizes for a cleaner, more consistent experience on tablets and phones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->