### PR TITLE
feat: Add Upload Claims modal to Claims Management page

### DIFF
--- a/Kuve-AKU-1/npm_output.log
+++ b/Kuve-AKU-1/npm_output.log
@@ -1,0 +1,3 @@
+
+> vite-react-app@0.0.0 dev
+> vite

--- a/Kuve-AKU-1/src/components/ClaimsManagement.tsx
+++ b/Kuve-AKU-1/src/components/ClaimsManagement.tsx
@@ -1,27 +1,34 @@
-import React from 'react';
+import React, { useState } from 'react';
+import UploadClaimsModal from './UploadClaimsModal';
 import './ClaimsManagement.css';
 
 const ClaimsManagement = () => {
-  return (
-    <div className="claims-management">
-      <header className="header">
-        <div>
-          <h1 className="header-title">Claims Management</h1>
-          <p className="header-subtitle">View and manage all denial claims in detail</p>
-        </div>
-        <div className="header-actions">
-          <button className="header-button">
-            <svg xmlns="http://www.w3.org/2000/svg" className="header-button-icon" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clipRule="evenodd" /></svg>
-            Search from Provider
-          </button>
-          <button className="header-button primary">
-            <svg xmlns="http://www.w3.org/2000/svg" className="header-button-icon" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM6.293 6.707a1 1 0 010-1.414l3-3a1 1 0 011.414 0l3 3a1 1 0 01-1.414 1.414L11 5.414V13a1 1 0 11-2 0V5.414L7.707 6.707a1 1 0 01-1.414 0z" clipRule="evenodd" /></svg>
-            Upload Claims
-          </button>
-        </div>
-      </header>
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
-      <div className="claims-stat-cards">
+  const handleOpenModal = () => setIsModalOpen(true);
+  const handleCloseModal = () => setIsModalOpen(false);
+
+  return (
+    <>
+      <div className="claims-management">
+        <header className="header">
+          <div>
+            <h1 className="header-title">Claims Management</h1>
+            <p className="header-subtitle">View and manage all denial claims in detail</p>
+          </div>
+          <div className="header-actions">
+            <button className="header-button">
+              <svg xmlns="http://www.w3.org/2000/svg" className="header-button-icon" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clipRule="evenodd" /></svg>
+              Search from Provider
+            </button>
+            <button className="header-button primary" onClick={handleOpenModal}>
+              <svg xmlns="http://www.w3.org/2000/svg" className="header-button-icon" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM6.293 6.707a1 1 0 010-1.414l3-3a1 1 0 011.414 0l3 3a1 1 0 01-1.414 1.414L11 5.414V13a1 1 0 11-2 0V5.414L7.707 6.707a1 1 0 01-1.414 0z" clipRule="evenodd" /></svg>
+              Upload Claims
+            </button>
+          </div>
+        </header>
+
+        <div className="claims-stat-cards">
         <div className="stat-card claims">
           <div className="card-content">
             <div className="card-icon">
@@ -96,46 +103,46 @@ const ClaimsManagement = () => {
         </div>
       </div>
 
-      <div className="claims-table-container">
-        <div className="claims-table-header">
-          <div className="tabs">
-            <button className="tab-button active">All Claims</button>
-            <button className="tab-button">In Process</button>
-            <button className="tab-button">Needs Review</button>
-            <button className="tab-button">Sent</button>
-            <button className="tab-button">Resubmission</button>
-            <button className="tab-button">Appeal</button>
-          </div>
-          <div className="table-actions">
-            <div className="search-bar">
-              <svg xmlns="http://www.w3.org/2000/svg" className="search-icon" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clipRule="evenodd" /></svg>
-              <input type="text" placeholder="Type to search..." />
+        <div className="claims-table-container">
+          <div className="claims-table-header">
+            <div className="tabs">
+              <button className="tab-button active">All Claims</button>
+              <button className="tab-button">In Process</button>
+              <button className="tab-button">Needs Review</button>
+              <button className="tab-button">Sent</button>
+              <button className="tab-button">Resubmission</button>
+              <button className="tab-button">Appeal</button>
             </div>
-            <button className="filter-button">
-              <svg xmlns="http://www.w3.org/2000/svg" className="filter-icon" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M3 3a1 1 0 011-1h12a1 1 0 011 1v3a1 1 0 01-.293.707L12 12.414V17a1 1 0 01-1.447.894l-2-1A1 1 0 018 16v-3.586L3.293 6.707A1 1 0 013 6V3z" clipRule="evenodd" /></svg>
-              Filter
-            </button>
-            <button className="export-button">
-              <svg xmlns="http://www.w3.org/2000/svg" className="export-icon" viewBox="0 0 20 20" fill="currentColor"><path d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" /></svg>
-              Export
-            </button>
+            <div className="table-actions">
+              <div className="search-bar">
+                <svg xmlns="http://www.w3.org/2000/svg" className="search-icon" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clipRule="evenodd" /></svg>
+                <input type="text" placeholder="Type to search..." />
+              </div>
+              <button className="filter-button">
+                <svg xmlns="http://www.w3.org/2000/svg" className="filter-icon" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M3 3a1 1 0 011-1h12a1 1 0 011 1v3a1 1 0 01-.293.707L12 12.414V17a1 1 0 01-1.447.894l-2-1A1 1 0 018 16v-3.586L3.293 6.707A1 1 0 013 6V3z" clipRule="evenodd" /></svg>
+                Filter
+              </button>
+              <button className="export-button">
+                <svg xmlns="http://www.w3.org/2000/svg" className="export-icon" viewBox="0 0 20 20" fill="currentColor"><path d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" /></svg>
+                Export
+              </button>
+            </div>
           </div>
-        </div>
-      <div className="claims-table-wrapper">
-        <table className="claims-table">
-          <thead>
-            <tr>
-              <th>Claim ID</th>
-              <th>Customer</th>
-              <th>Provider</th>
-              <th>Payer</th>
-              <th>Date Issued</th>
-              <th>Amount</th>
-              <th>Status</th>
-              <th></th>
-            </tr>
-          </thead>
-          <tbody>
+        <div className="claims-table-wrapper">
+          <table className="claims-table">
+            <thead>
+              <tr>
+                <th>Claim ID</th>
+                <th>Customer</th>
+                <th>Provider</th>
+                <th>Payer</th>
+                <th>Date Issued</th>
+                <th>Amount</th>
+                <th>Status</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
             <tr>
               <td>AKU-2025-627</td>
               <td>Raul Sampson</td>
@@ -227,10 +234,12 @@ const ClaimsManagement = () => {
               <td className="action-dots">...</td>
             </tr>
           </tbody>
-        </table>
+          </table>
+        </div>
+        </div>
       </div>
-      </div>
-    </div>
+      <UploadClaimsModal isOpen={isModalOpen} onClose={handleCloseModal} />
+    </>
   );
 };
 

--- a/Kuve-AKU-1/src/components/UploadClaimsModal.css
+++ b/Kuve-AKU-1/src/components/UploadClaimsModal.css
@@ -1,0 +1,198 @@
+/* UploadClaimsModal.css */
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 500px;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.close-button {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  color: #9ca3af;
+  width: 1.5rem;
+  height: 1.5rem;
+}
+.close-button:hover {
+    color: #6b7280;
+}
+
+.modal-body {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.form-group label {
+  margin-bottom: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+}
+
+.select-wrapper {
+  position: relative;
+}
+
+.select-wrapper select {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background-color: white;
+  font-size: 1rem;
+  appearance: none; /* Remove default arrow */
+  -webkit-appearance: none;
+  -moz-appearance: none;
+}
+
+.select-wrapper::after {
+  content: '▼';
+  font-size: 0.8rem;
+  position: absolute;
+  right: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  color: #6b7280;
+}
+
+.file-upload-area {
+  border: 2px dashed #d1d5db;
+  border-radius: 6px;
+  padding: 2rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.file-upload-icon {
+  width: 3rem;
+  height: 3rem;
+  color: #6b7280;
+  margin-bottom: 1rem;
+}
+
+.file-upload-text {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  color: #374151;
+}
+
+.file-upload-subtext {
+  margin: 0 0 1rem;
+  font-size: 0.875rem;
+  color: #6b7280;
+}
+
+.choose-file-button {
+  background-color: #f3f4f6;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+  cursor: pointer;
+}
+
+.choose-file-button:hover {
+    background-color: #e5e7eb;
+}
+
+.expected-format {
+  background-color: #f9fafb;
+  border-radius: 6px;
+  padding: 1rem;
+}
+
+.expected-format label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.expected-format p {
+  font-size: 0.875rem;
+  color: #6b7280;
+  margin: 0;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 1rem 1.5rem;
+  border-top: 1px solid #e5e7eb;
+}
+
+.footer-button {
+  padding: 0.625rem 1rem;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.footer-button.cancel {
+  background-color: white;
+  border-color: #d1d5db;
+  color: #374151;
+}
+.footer-button.cancel:hover {
+    background-color: #f9fafb;
+}
+
+.footer-button.upload {
+  background-color: #4b5563; /* Medium gray */
+  color: white;
+}
+
+.footer-button.upload:hover {
+    background-color: #374151;
+}

--- a/Kuve-AKU-1/src/components/UploadClaimsModal.tsx
+++ b/Kuve-AKU-1/src/components/UploadClaimsModal.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import './UploadClaimsModal.css';
+
+interface UploadClaimsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const UploadClaimsModal: React.FC<UploadClaimsModalProps> = ({ isOpen, onClose }) => {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-content">
+        <header className="modal-header">
+          <h2>Upload Claims</h2>
+          <button className="close-button" onClick={onClose}>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+            </svg>
+          </button>
+        </header>
+        <div className="modal-body">
+          <div className="form-group">
+            <label htmlFor="provider-select">Select Provider</label>
+            <div className="select-wrapper">
+              <select id="provider-select" defaultValue="">
+                <option value="" disabled>Choose Provider</option>
+                <option value="provider1">Provider One</option>
+                <option value="provider2">Provider Two</option>
+                <option value="provider3">Provider Three</option>
+              </select>
+            </div>
+          </div>
+
+          <div className="file-upload-area">
+            <div className="file-upload-icon">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" > <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m.75 12l3 3m0 0l3-3m-3 3v-6m-1.5-9H5.625a1.875 1.875 0 00-1.875 1.875v17.25a1.875 1.875 0 001.875 1.875h12.75a1.875 1.875 0 001.875-1.875V10.5M8.25 17.25h.008v.008H8.25v-.008z" /> </svg>
+            </div>
+            <p className="file-upload-text">
+              <strong>Drop your claims file here or click to browse</strong>
+            </p>
+            <p className="file-upload-subtext">Supports Excel (.xlsx), CSV, and Word documents</p>
+            <button className="choose-file-button">Choose File</button>
+          </div>
+
+          <div className="expected-format">
+            <label>Expected format:</label>
+            <p>Patient Name, Claim Number, Age, Diagnosis, Treatment, Amount, Date</p>
+          </div>
+        </div>
+        <footer className="modal-footer">
+          <button className="footer-button cancel" onClick={onClose}>Cancel</button>
+          <button className="footer-button upload">Upload and Process</button>
+        </footer>
+      </div>
+    </div>
+  );
+};
+
+export default UploadClaimsModal;


### PR DESCRIPTION
This commit introduces the "Upload Claims" modal, which appears when the corresponding button is clicked on the Claims Management page.

Key changes include:
- Created a new `UploadClaimsModal` component with a detailed structure, including a provider dropdown, file upload area, and formatted content guide.
- Styled the modal to be a pixel-perfect match of the provided design, including the overlay, layout, and all interactive elements.
- Integrated the modal into the `ClaimsManagement` component using state and event handlers to control its visibility.
- Ensured the application's main user flow (splash screen -> login -> dashboard) remains correct and functional.
- Verified the modal's functionality and appearance with a Playwright script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added an Upload Claims modal in Claims Management.
  * Includes provider selection, file chooser, and expected format note.
  * Cancel and Upload actions, plus close control.

* Style
  * Introduced dedicated styling for modal overlay, content, form groups, and buttons.
  * Enhanced file upload area with dashed drop zone and icon.
  * Added hover and interactive states for controls.

* Refactor
  * Minor layout adjustments around the claims header and table to accommodate the modal.
  * Preserves existing data display and interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->