### PR TITLE
feat: Enhance Upload Claims modal with dynamic states

### DIFF
--- a/Kuve-AKU-1/src/components/UploadClaimsModal.css
+++ b/Kuve-AKU-1/src/components/UploadClaimsModal.css
@@ -81,7 +81,7 @@
   border-radius: 6px;
   background-color: white;
   font-size: 1rem;
-  appearance: none; /* Remove default arrow */
+  appearance: none;
   -webkit-appearance: none;
   -moz-appearance: none;
 }
@@ -95,6 +95,24 @@
   transform: translateY(-50%);
   pointer-events: none;
   color: #6b7280;
+}
+
+.provider-display {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background-color: #f9fafb;
+  font-size: 1rem;
+  color: #374151;
+}
+
+.provider-icon {
+    width: 1.25rem;
+    height: 1.25rem;
+    color: #6b7280;
 }
 
 .file-upload-area {
@@ -142,6 +160,22 @@
     background-color: #e5e7eb;
 }
 
+.file-display {
+    text-align: center;
+}
+
+.file-name {
+    font-weight: 600;
+    color: #374151;
+    margin: 0 0 0.25rem;
+}
+
+.file-size {
+    font-size: 0.875rem;
+    color: #6b7280;
+    margin: 0;
+}
+
 .expected-format {
   background-color: #f9fafb;
   border-radius: 6px;
@@ -177,6 +211,7 @@
   font-weight: 500;
   cursor: pointer;
   border: 1px solid transparent;
+  transition: background-color 0.2s;
 }
 
 .footer-button.cancel {
@@ -189,10 +224,19 @@
 }
 
 .footer-button.upload {
-  background-color: #4b5563; /* Medium gray */
+  background-color: #2E5BBA;
   color: white;
 }
 
 .footer-button.upload:hover {
-    background-color: #374151;
+    background-color: #254a9c;
+}
+
+.footer-button.upload.disabled {
+  background-color: #9ca3af;
+  cursor: not-allowed;
+}
+
+.footer-button.upload.disabled:hover {
+    background-color: #9ca3af;
 }

--- a/Kuve-AKU-1/src/components/UploadClaimsModal.tsx
+++ b/Kuve-AKU-1/src/components/UploadClaimsModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useRef } from 'react';
 import './UploadClaimsModal.css';
 
 interface UploadClaimsModalProps {
@@ -7,16 +7,39 @@ interface UploadClaimsModalProps {
 }
 
 const UploadClaimsModal: React.FC<UploadClaimsModalProps> = ({ isOpen, onClose }) => {
+  const [selectedProvider, setSelectedProvider] = useState<string>('');
+  const [uploadedFile, setUploadedFile] = useState<File | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files && event.target.files.length > 0) {
+      setUploadedFile(event.target.files[0]);
+    }
+  };
+
+  const handleChooseFileClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleClose = () => {
+    // Reset state on close
+    setSelectedProvider('');
+    setUploadedFile(null);
+    onClose();
+  };
+
   if (!isOpen) {
     return null;
   }
+
+  const isUploadDisabled = !selectedProvider || !uploadedFile;
 
   return (
     <div className="modal-overlay">
       <div className="modal-content">
         <header className="modal-header">
           <h2>Upload Claims</h2>
-          <button className="close-button" onClick={onClose}>
+          <button className="close-button" onClick={handleClose}>
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
               <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
             </svg>
@@ -25,25 +48,42 @@ const UploadClaimsModal: React.FC<UploadClaimsModalProps> = ({ isOpen, onClose }
         <div className="modal-body">
           <div className="form-group">
             <label htmlFor="provider-select">Select Provider</label>
-            <div className="select-wrapper">
-              <select id="provider-select" defaultValue="">
-                <option value="" disabled>Choose Provider</option>
-                <option value="provider1">Provider One</option>
-                <option value="provider2">Provider Two</option>
-                <option value="provider3">Provider Three</option>
-              </select>
-            </div>
+            {!selectedProvider ? (
+              <div className="select-wrapper">
+                <select id="provider-select" value={selectedProvider} onChange={(e) => setSelectedProvider(e.target.value)}>
+                  <option value="" disabled>Choose Provider</option>
+                  <option value="OAUTH">OAUTH</option>
+                  <option value="UCH">UCH</option>
+                  <option value="LANDMARK">LANDMARK</option>
+                </select>
+              </div>
+            ) : (
+              <div className="provider-display">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="provider-icon"><path strokeLinecap="round" strokeLinejoin="round" d="M3.75 9.776c.112-.017.227-.026.344-.026h15.812c.117 0 .232.009.344.026m-16.5 0a2.25 2.25 0 00-1.883 2.542l.857 6a2.25 2.25 0 002.227 1.932H19.05a2.25 2.25 0 002.227-1.932l.857-6a2.25 2.25 0 00-1.883-2.542m-16.5 0A2.25 2.25 0 015.625 7.5h12.75a2.25 2.25 0 012.25 2.25m-15 0h15" /></svg>
+                {selectedProvider}
+              </div>
+            )}
           </div>
 
           <div className="file-upload-area">
+            <input type="file" ref={fileInputRef} onChange={handleFileChange} style={{ display: 'none' }} accept=".xlsx,.csv,.docx" />
             <div className="file-upload-icon">
-                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" > <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m.75 12l3 3m0 0l3-3m-3 3v-6m-1.5-9H5.625a1.875 1.875 0 00-1.875 1.875v17.25a1.875 1.875 0 001.875 1.875h12.75a1.875 1.875 0 001.875-1.875V10.5M8.25 17.25h.008v.008H8.25v-.008z" /> </svg>
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor"> <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m.75 12l3 3m0 0l3-3m-3 3v-6m-1.5-9H5.625a1.875 1.875 0 00-1.875 1.875v17.25a1.875 1.875 0 001.875 1.875h12.75a1.875 1.875 0 001.875-1.875V10.5M8.25 17.25h.008v.008H8.25v-.008z" /> </svg>
             </div>
-            <p className="file-upload-text">
-              <strong>Drop your claims file here or click to browse</strong>
-            </p>
-            <p className="file-upload-subtext">Supports Excel (.xlsx), CSV, and Word documents</p>
-            <button className="choose-file-button">Choose File</button>
+            {!uploadedFile ? (
+              <>
+                <p className="file-upload-text">
+                  <strong>Drop your claims file here or click to browse</strong>
+                </p>
+                <p className="file-upload-subtext">Supports Excel (.xlsx), CSV, and Word documents</p>
+                <button className="choose-file-button" onClick={handleChooseFileClick}>Choose File</button>
+              </>
+            ) : (
+              <div className="file-display">
+                <p className="file-name">{uploadedFile.name}</p>
+                <p className="file-size">{(uploadedFile.size / 1024).toFixed(2)} KB</p>
+              </div>
+            )}
           </div>
 
           <div className="expected-format">
@@ -52,8 +92,10 @@ const UploadClaimsModal: React.FC<UploadClaimsModalProps> = ({ isOpen, onClose }
           </div>
         </div>
         <footer className="modal-footer">
-          <button className="footer-button cancel" onClick={onClose}>Cancel</button>
-          <button className="footer-button upload">Upload and Process</button>
+          <button className="footer-button cancel" onClick={handleClose}>Cancel</button>
+          <button className={`footer-button upload ${isUploadDisabled ? 'disabled' : ''}`} disabled={isUploadDisabled}>
+            Upload and Process
+          </button>
         </footer>
       </div>
     </div>


### PR DESCRIPTION
This commit enhances the "Upload Claims" modal with dynamic UI states based on user interaction, including provider selection and file upload.

Key changes include:
- Implemented state management in `UploadClaimsModal.tsx` to track the selected provider and uploaded file.
- Used conditional rendering to dynamically update the UI, showing a read-only field for the selected provider and displaying the filename and size after a file is chosen.
- The "Upload and Process" button is now conditionally disabled until both a provider and a file are selected, with its styling updated to reflect the enabled/disabled state.
- A hidden file input is used to allow for custom styling of the file upload trigger.
- The modal's state is reset when it is closed to ensure a clean state for the next use.
- Verified the new functionality with a Playwright script that tests the state transitions and final UI.