### PR TITLE
Fix: Relocate Dashboard Header to Correct Position

### DIFF
--- a/Kuve-AKU-1/src/components/Dashboard.css
+++ b/Kuve-AKU-1/src/components/Dashboard.css
@@ -126,9 +126,61 @@
   overflow-y: auto;
   padding: 2rem;
   display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.dashboard-body {
+  display: flex;
   flex-direction: row;
   gap: 16px; /* This creates the margin between the Alert Panel and the main content */
   align-items: flex-start;
+  flex: 1;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 8px; /* Reduced from 24px */
+}
+
+.header-title {
+  font-size: 28px;
+  font-weight: 700;
+  color: #111827;
+  margin: 0;
+}
+
+.header-subtitle {
+  font-size: 14px;
+  color: #6B7280;
+  margin-top: 4px;
+}
+
+.timeframe-selector {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background-color: #FFFFFF;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid #E5E7EB;
+  font-size: 14px;
+  font-weight: 500;
+  color: #374151;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.timeframe-selector:hover {
+  background-color: #F3F4F6;
+}
+
+.dropdown-icon {
+  width: 20px;
+  height: 20px;
+  color: #9CA3AF;
 }
 
 .left-column, .right-column {

--- a/Kuve-AKU-1/src/components/Dashboard.tsx
+++ b/Kuve-AKU-1/src/components/Dashboard.tsx
@@ -62,8 +62,20 @@ const Dashboard = () => {
         </div>
       </aside>
       <main className="main-content-dashboard">
+        <header className="header">
+          <div>
+            <h1 className="header-title">Dashboard Overview</h1>
+            <p className="header-subtitle">Real-time akuvera AI processing and claim resolution monitoring</p>
+          </div>
+          <div className="timeframe-selector">
+            Timeframe: This Month
+            <svg xmlns="http://www.w3.org/2000/svg" className="dropdown-icon" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clipRule="evenodd" />
+            </svg>
+          </div>
+        </header>
         {activeView === 'overview' ? (
-          <>
+          <div className="dashboard-body">
             <div className="left-column">
               <AlertPanel />
               <RecentActivity />
@@ -72,7 +84,7 @@ const Dashboard = () => {
               <DashboardOverview />
               <AiLearningInsights />
             </div>
-          </>
+          </div>
         ) : (
           <ClaimsManagement />
         )}

--- a/Kuve-AKU-1/src/components/DashboardOverview.css
+++ b/Kuve-AKU-1/src/components/DashboardOverview.css
@@ -1,50 +1,5 @@
-.header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  margin-bottom: 24px;
-}
-
 .charts-section {
   margin-bottom: 24px;
-}
-
-.header-title {
-  font-size: 28px;
-  font-weight: 700;
-  color: #111827;
-  margin: 0;
-}
-
-.header-subtitle {
-  font-size: 14px;
-  color: #6B7280;
-  margin-top: 4px;
-}
-
-.timeframe-selector {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  background-color: #FFFFFF;
-  padding: 8px 12px;
-  border-radius: 8px;
-  border: 1px solid #E5E7EB;
-  font-size: 14px;
-  font-weight: 500;
-  color: #374151;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-.timeframe-selector:hover {
-  background-color: #F3F4F6;
-}
-
-.dropdown-icon {
-  width: 20px;
-  height: 20px;
-  color: #9CA3AF;
 }
 
 .stat-cards {

--- a/Kuve-AKU-1/src/components/DashboardOverview.tsx
+++ b/Kuve-AKU-1/src/components/DashboardOverview.tsx
@@ -60,19 +60,6 @@ const CustomTooltip = ({ active, payload }: any) => {
 const DashboardOverview = () => {
   return (
     <>
-      <header className="header">
-        <div>
-          <h1 className="header-title">Dashboard Overview</h1>
-          <p className="header-subtitle">Real-time akuvera AI processing and claim resolution monitoring</p>
-        </div>
-        <div className="timeframe-selector">
-          Timeframe: This Month
-          <svg xmlns="http://www.w3.org/2000/svg" className="dropdown-icon" viewBox="0 0 20 20" fill="currentColor">
-            <path fillRule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clipRule="evenodd" />
-          </svg>
-        </div>
-      </header>
-
       <div className="stat-cards">
         <div className="stat-card">
           <div className="stat-card-icon-container">


### PR DESCRIPTION
The dashboard header, containing the title and timeframe selector, was previously located within the `DashboardOverview` component. This confined it to the right column of the dashboard layout, which did not match the intended design.

This commit refactors the layout by moving the header from `DashboardOverview.tsx` to the parent `Dashboard.tsx` component. This places the header correctly at the top of the main content area, spanning the full width above the two-column layout.

The associated CSS has also been moved from `DashboardOverview.css` to `Dashboard.css` to ensure the styling remains consistent. The main content container was updated to a column flex layout to accommodate the header, and the two-column structure is now wrapped in a new `dashboard-body` element.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a unified dashboard header with title, subtitle, and a timeframe selector visible across all views.
  - Implemented a more responsive, flexible dashboard layout for better space sharing between panels.
- Style
  - Updated spacing, typography, and hover states for improved readability and interactivity.
  - Polished card and chart area spacing for a cleaner visual hierarchy.
- Refactor
  - Moved the header from the Overview section to the main Dashboard and reorganized content containers for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->