### PR TITLE
fix: Align Recent Activity and AI Learning Insights horizontally

### DIFF
--- a/Kuve-AKU-1/src/components/Dashboard.css
+++ b/Kuve-AKU-1/src/components/Dashboard.css
@@ -138,6 +138,6 @@
 }
 
 .grid-item-alert { grid-column: 1 / 2; }
-.grid-item-overview { grid-column: 2 / 3; grid-row: 1 / 3; }
+.grid-item-overview { grid-column: 2 / 3; }
 .grid-item-activity { grid-column: 1 / 2; }
 .grid-item-insights { grid-column: 2 / 3; }


### PR DESCRIPTION
This commit adjusts the CSS grid layout for the main dashboard.

By removing the `grid-row: 1 / 3;` property from the `.grid-item-overview` class, the component no longer spans two rows. This allows the `.grid-item-activity` and `.grid-item-insights` components to render on the same horizontal level, as intended by the design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dashboard layout to refine positioning of the Overview tile within the grid, improving visual balance and consistency.
  * Removed forced vertical spanning to prevent awkward stretching and to enhance responsiveness across different screen sizes, resulting in cleaner spacing and better alignment with adjacent tiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->