### PR TITLE
fix: Move dashboard header to the correct top-level position

### DIFF
--- a/Kuve-AKU-1/src/components/Dashboard.css
+++ b/Kuve-AKU-1/src/components/Dashboard.css
@@ -130,6 +130,51 @@
   gap: 24px; /* Gap between header and body */
 }
 
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 24px;
+}
+
+.header-title {
+  font-size: 28px;
+  font-weight: 700;
+  color: #111827;
+  margin: 0;
+}
+
+.header-subtitle {
+  font-size: 14px;
+  color: #6B7280;
+  margin-top: 4px;
+}
+
+.timeframe-selector {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background-color: #FFFFFF;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid #E5E7EB;
+  font-size: 14px;
+  font-weight: 500;
+  color: #374151;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.timeframe-selector:hover {
+  background-color: #F3F4F6;
+}
+
+.dropdown-icon {
+  width: 20px;
+  height: 20px;
+  color: #9CA3AF;
+}
+
 .dashboard-grid {
   display: grid;
   grid-template-columns: 1fr 2fr; /* 1fr for the left column, 2fr for the right */

--- a/Kuve-AKU-1/src/components/Dashboard.tsx
+++ b/Kuve-AKU-1/src/components/Dashboard.tsx
@@ -62,6 +62,18 @@ const Dashboard = () => {
         </div>
       </aside>
       <main className="main-content-dashboard">
+        <header className="header">
+            <div>
+              <h1 className="header-title">Dashboard Overview</h1>
+              <p className="header-subtitle">Real-time akuvera AI processing and claim resolution monitoring</p>
+            </div>
+            <div className="timeframe-selector">
+              Timeframe: This Month
+              <svg xmlns="http://www.w3.org/2000/svg" className="dropdown-icon" viewBox="0 0 20 20" fill="currentColor">
+                <path fillRule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clipRule="evenodd" />
+              </svg>
+            </div>
+        </header>
         {activeView === 'overview' ? (
             <div className="dashboard-grid">
                 <div className="grid-item-alert"><AlertPanel /></div>

--- a/Kuve-AKU-1/src/components/DashboardOverview.css
+++ b/Kuve-AKU-1/src/components/DashboardOverview.css
@@ -1,50 +1,5 @@
-.header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  margin-bottom: 24px;
-}
-
 .charts-section {
   margin-bottom: 24px;
-}
-
-.header-title {
-  font-size: 28px;
-  font-weight: 700;
-  color: #111827;
-  margin: 0;
-}
-
-.header-subtitle {
-  font-size: 14px;
-  color: #6B7280;
-  margin-top: 4px;
-}
-
-.timeframe-selector {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  background-color: #FFFFFF;
-  padding: 8px 12px;
-  border-radius: 8px;
-  border: 1px solid #E5E7EB;
-  font-size: 14px;
-  font-weight: 500;
-  color: #374151;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-.timeframe-selector:hover {
-  background-color: #F3F4F6;
-}
-
-.dropdown-icon {
-  width: 20px;
-  height: 20px;
-  color: #9CA3AF;
 }
 
 .stat-cards {

--- a/Kuve-AKU-1/src/components/DashboardOverview.tsx
+++ b/Kuve-AKU-1/src/components/DashboardOverview.tsx
@@ -33,19 +33,6 @@ const CustomTooltip = ({ active, payload }: any) => {
 const DashboardOverview = () => {
   return (
     <>
-      <header className="header">
-        <div>
-          <h1 className="header-title">Dashboard Overview</h1>
-          <p className="header-subtitle">Real-time akuvera AI processing and claim resolution monitoring</p>
-        </div>
-        <div className="timeframe-selector">
-          Timeframe: This Month
-          <svg xmlns="http://www.w3.org/2000/svg" className="dropdown-icon" viewBox="0 0 20 20" fill="currentColor">
-            <path fillRule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clipRule="evenodd" />
-          </svg>
-        </div>
-      </header>
-
       <div className="stat-cards">
         <div className="stat-card">
           <div className="stat-card-icon-container">


### PR DESCRIPTION
This commit refactors the main dashboard to correctly position the header.

The `<header>` element, which contains the "Dashboard Overview" title and the timeframe selector, was previously located inside the `DashboardOverview` component. This confined it to a grid cell.

To fix this, the `<header>` has been moved to the parent `Dashboard` component, placing it directly within the `<main>` content area, above the grid container. The associated CSS styles have also been moved from `DashboardOverview.css` to `Dashboard.css` to ensure they are applied correctly.

This change ensures the header spans the full width of the main content area, matching the intended design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a unified dashboard header with title, subtitle, and a timeframe selector.

- Style
  - Added styling for the new dashboard header, including layout, typography, and hover states.
  - Removed redundant header styles from the overview to streamline the UI.

- Refactor
  - Consolidated header from the overview into the main dashboard for a consistent, centralized experience across views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->