### PR TITLE
fix: Conditionally render dashboard header

### DIFF
--- a/Kuve-AKU-1/src/components/Dashboard.tsx
+++ b/Kuve-AKU-1/src/components/Dashboard.tsx
@@ -62,18 +62,20 @@ const Dashboard = () => {
         </div>
       </aside>
       <main className="main-content-dashboard">
-        <header className="header">
-            <div>
-              <h1 className="header-title">Dashboard Overview</h1>
-              <p className="header-subtitle">Real-time akuvera AI processing and claim resolution monitoring</p>
-            </div>
-            <div className="timeframe-selector">
-              Timeframe: This Month
-              <svg xmlns="http://www.w3.org/2000/svg" className="dropdown-icon" viewBox="0 0 20 20" fill="currentColor">
-                <path fillRule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clipRule="evenodd" />
-              </svg>
-            </div>
-        </header>
+        {activeView === 'overview' && (
+          <header className="header">
+              <div>
+                <h1 className="header-title">Dashboard Overview</h1>
+                <p className="header-subtitle">Real-time akuvera AI processing and claim resolution monitoring</p>
+              </div>
+              <div className="timeframe-selector">
+                Timeframe: This Month
+                <svg xmlns="http://www.w3.org/2000/svg" className="dropdown-icon" viewBox="0 0 20 20" fill="currentColor">
+                  <path fillRule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clipRule="evenodd" />
+                </svg>
+              </div>
+          </header>
+        )}
         {activeView === 'overview' ? (
             <div className="dashboard-grid">
                 <div className="grid-item-alert"><AlertPanel /></div>


### PR DESCRIPTION
This commit ensures the main dashboard header is only displayed on the "Overview" page and not on other views like "Claims".

The `<header>` element in `Dashboard.tsx` has been wrapped in a conditional rendering block that checks if the `activeView` state is 'overview'. This prevents the header from appearing on other pages, correcting the layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard header now displays only in the Overview view, preventing it from appearing on other sections and removing unintended duplicate headings.
  * Header content and styling remain unchanged; only its visibility has been corrected to match the selected view.
  * Improves clarity and reduces visual clutter, providing a cleaner navigation experience and clearer context as users switch between views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->