### PR TITLE
fix: Align Claims Management content to top-left

### DIFF
--- a/Kuve-AKU-1/src/components/Dashboard.tsx
+++ b/Kuve-AKU-1/src/components/Dashboard.tsx
@@ -83,9 +83,8 @@ const Dashboard = () => {
                 <div className="grid-item-activity"><RecentActivity /></div>
                 <div className="grid-item-insights"><AiLearningInsights /></div>
             </div>
-        ) : (
-          <ClaimsManagement />
-        )}
+        ) : null}
+        {activeView === 'claims' && <ClaimsManagement />}
       </main>
     </div>
   );


### PR DESCRIPTION
This change corrects a layout issue on the 'Claims Management' page. The `ClaimsManagement` component was previously rendered inside a CSS grid, causing its content to be misaligned.

This commit refactors the rendering logic in `Dashboard.tsx` to ensure the component is rendered outside the grid when the 'claims' view is active, allowing it to align correctly to the top-left of the main content area.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Fixed an issue where the Dashboard could show the Claims Management view when another section was selected. Claims Management now appears only when explicitly chosen, improving navigation clarity.
  - Enhanced view switching to consistently display the correct content, reducing unexpected screen changes and improving overall dashboard usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->