### PR TITLE
Fix: Align Claims Management view with Dashboard

### DIFF
--- a/Kuve-AKU-1/src/components/ClaimsManagement.css
+++ b/Kuve-AKU-1/src/components/ClaimsManagement.css
@@ -21,8 +21,6 @@
 
 /* Global styles for the view */
 .claims-management {
-  padding: 2rem 2.5rem;
-  background-color: var(--light-gray-bg);
   /* height: 100%; */ /* <-- Removed to fix top-left alignment */
   font-family: 'Inter', sans-serif;
 }

--- a/Kuve-AKU-1/src/components/Dashboard.css
+++ b/Kuve-AKU-1/src/components/Dashboard.css
@@ -175,7 +175,7 @@
   color: #9CA3AF;
 }
 
-.dashboard-grid {
+.dashboard-grid, .claims-management-view {
   display: grid;
   grid-template-columns: 1fr 2fr; /* 1fr for the left column, 2fr for the right */
   gap: 24px;
@@ -186,3 +186,8 @@
 .grid-item-overview { grid-column: 2 / 3; }
 .grid-item-activity { grid-column: 1 / 2; }
 .grid-item-insights { grid-column: 2 / 3; }
+
+/* Let the claims management component take the full width of the grid */
+.claims-management-view .claims-management {
+  grid-column: 1 / -1;
+}

--- a/Kuve-AKU-1/src/components/Dashboard.tsx
+++ b/Kuve-AKU-1/src/components/Dashboard.tsx
@@ -84,7 +84,7 @@ const Dashboard = () => {
                 <div className="grid-item-insights"><AiLearningInsights /></div>
             </div>
         ) : null}
-        {activeView === 'claims' && <ClaimsManagement />}
+        {activeView === 'claims' && <div className="claims-management-view"><ClaimsManagement /></div>}
       </main>
     </div>
   );


### PR DESCRIPTION
This commit fixes a layout issue where the Claims Management view was not aligned with the Dashboard view.

The following changes were made:
- Removed padding and background-color from the `.claims-management` class to prevent it from interfering with the grid layout.
- Wrapped the `ClaimsManagement` component in a `div` with a new class, `claims-management-view`.
- Added styles to `Dashboard.css` to make the `claims-management-view` a grid container and to make the `claims-management` component span the full width of the grid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Claims Management now aligns with the dashboard’s two‑column grid and can span full width for better readability.
  * Removed extra padding and background color from the claims area for a cleaner, more consistent look.
  * Preserves existing placement of dashboard widgets while improving layout consistency.

* **Refactor**
  * Wrapped the Claims Management view in a container to integrate with the grid layout.
  * No changes to behavior, controls, or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->