### PR TITLE
Refactor: Align Claims Management header with Dashboard

### DIFF
--- a/Kuve-AKU-1/src/components/ClaimsManagement.css
+++ b/Kuve-AKU-1/src/components/ClaimsManagement.css
@@ -21,94 +21,12 @@
 
 /* Global styles for the view */
 .claims-management {
+  padding: 2rem 2.5rem;
+  background-color: var(--light-gray-bg);
   /* height: 100%; */ /* <-- Removed to fix top-left alignment */
   font-family: 'Inter', sans-serif;
 }
 
-/* Header Section */
-.header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 2rem;
-}
-
-.header-title {
-  font-size: 28px;
-  font-weight: 700; /* Bold */
-  color: var(--primary-text);
-  margin: 0;
-}
-
-.header-subtitle {
-  font-size: 14px;
-  color: var(--secondary-text);
-  margin-top: 4px; /* Vertical padding */
-}
-
-.header-actions {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
-
-.search-bar-header {
-  display: flex;
-  align-items: center;
-  background-color: var(--background);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 6px 8px;
-}
-
-.search-bar-header .search-icon {
-  width: 20px;
-  height: 20px;
-  color: var(--blue);
-  margin-right: 8px;
-}
-
-.search-bar-header input {
-  border: none;
-  outline: none;
-  background-color: transparent;
-  color: var(--tertiary-text);
-  font-size: 14px;
-}
-
-.search-bar-header input::placeholder {
-  color: var(--blue);
-}
-
-.upload-claims-button {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  background-color: var(--background);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 8px 16px;
-  font-size: 14px;
-  font-weight: 700; /* Bold */
-  color: var(--blue);
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-.upload-claims-button:hover {
-  background-color: var(--hover-tint);
-}
-
-.upload-claims-button .upload-icon {
-  width: 20px;
-  height: 20px;
-  color: var(--blue);
-}
-
-.upload-claims-button .upload-icon path {
-    stroke: var(--blue);
-    stroke-width: 2;
-}
 
 
 /* --- Status Summary Cards --- */

--- a/Kuve-AKU-1/src/components/ClaimsManagement.tsx
+++ b/Kuve-AKU-1/src/components/ClaimsManagement.tsx
@@ -11,29 +11,6 @@ const ClaimsManagement = () => {
   return (
     <>
       <div className="claims-management">
-        <header className="header">
-          <div>
-            <h1 className="header-title">Claims Management</h1>
-            <p className="header-subtitle">View and manage all dental claims in detail</p>
-          </div>
-          <div className="header-actions">
-            <div className="search-bar-header">
-              <svg xmlns="http://www.w3.org/2000/svg" className="search-icon" viewBox="0 0 20 20" fill="currentColor">
-                <path fillRule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clipRule="evenodd" />
-              </svg>
-              <input type="text" placeholder="Search from Provider" />
-            </div>
-            <button className="upload-claims-button" onClick={handleOpenModal}>
-            <svg className="upload-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" >
-                <path d="M10 12.5V3.33331" strokeLinecap="round" strokeLinejoin="round"/>
-                <path d="M6.66669 6.66669L10 3.33335L13.3334 6.66669" strokeLinecap="round" strokeLinejoin="round"/>
-                <path d="M16.6667 10V16.6667H3.33331V10" strokeLinecap="round" strokeLinejoin="round"/>
-              </svg>
-              Upload Claims
-            </button>
-          </div>
-        </header>
-
         <div className="claims-stat-cards">
           {/* Claims Card */}
           <div className="stat-card claims">

--- a/Kuve-AKU-1/src/components/Dashboard.css
+++ b/Kuve-AKU-1/src/components/Dashboard.css
@@ -175,7 +175,7 @@
   color: #9CA3AF;
 }
 
-.dashboard-grid, .claims-management-view {
+.dashboard-grid {
   display: grid;
   grid-template-columns: 1fr 2fr; /* 1fr for the left column, 2fr for the right */
   gap: 24px;
@@ -186,8 +186,3 @@
 .grid-item-overview { grid-column: 2 / 3; }
 .grid-item-activity { grid-column: 1 / 2; }
 .grid-item-insights { grid-column: 2 / 3; }
-
-/* Let the claims management component take the full width of the grid */
-.claims-management-view .claims-management {
-  grid-column: 1 / -1;
-}

--- a/Kuve-AKU-1/src/components/Dashboard.tsx
+++ b/Kuve-AKU-1/src/components/Dashboard.tsx
@@ -6,8 +6,14 @@ import AlertPanel from './AlertPanel';
 import RecentActivity from './RecentActivity';
 import AiLearningInsights from './AiLearningInsights';
 
+import UploadClaimsModal from './UploadClaimsModal';
+
 const Dashboard = () => {
   const [activeView, setActiveView] = useState('overview'); // 'overview' or 'claims'
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleOpenModal = () => setIsModalOpen(true);
+  const handleCloseModal = () => setIsModalOpen(false);
 
   return (
     <div className="dashboard">
@@ -76,6 +82,30 @@ const Dashboard = () => {
               </div>
           </header>
         )}
+        {activeView === 'claims' && (
+            <header className="header">
+                <div>
+                    <h1 className="header-title">Claims Management</h1>
+                    <p className="header-subtitle">View and manage all dental claims in detail</p>
+                </div>
+                <div className="timeframe-selector">
+                    <div className="search-bar-header">
+                        <svg xmlns="http://www.w3.org/2000/svg" className="search-icon" viewBox="0 0 20 20" fill="currentColor">
+                            <path fillRule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clipRule="evenodd" />
+                        </svg>
+                        <input type="text" placeholder="Search from Provider" />
+                    </div>
+                    <button className="upload-claims-button" onClick={handleOpenModal}>
+                        <svg className="upload-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" >
+                            <path d="M10 12.5V3.33331" strokeLinecap="round" strokeLinejoin="round"/>
+                            <path d="M6.66669 6.66669L10 3.33335L13.3334 6.66669" strokeLinecap="round" strokeLinejoin="round"/>
+                            <path d="M16.6667 10V16.6667H3.33331V10" strokeLinecap="round" strokeLinejoin="round"/>
+                        </svg>
+                        Upload Claims
+                    </button>
+                </div>
+            </header>
+        )}
         {activeView === 'overview' ? (
             <div className="dashboard-grid">
                 <div className="grid-item-alert"><AlertPanel /></div>
@@ -84,8 +114,9 @@ const Dashboard = () => {
                 <div className="grid-item-insights"><AiLearningInsights /></div>
             </div>
         ) : null}
-        {activeView === 'claims' && <div className="claims-management-view"><ClaimsManagement /></div>}
+        {activeView === 'claims' && <ClaimsManagement />}
       </main>
+      <UploadClaimsModal isOpen={isModalOpen} onClose={handleCloseModal} />
     </div>
   );
 };


### PR DESCRIPTION
This commit refactors the `Dashboard` and `ClaimsManagement` components to align the headers of the "Dashboard Overview" and "Claims Management" views.

The header has been extracted from the `ClaimsManagement` component and moved to the `Dashboard` component. It is now rendered conditionally based on the active view, ensuring both views share the same header structure and alignment. The corresponding CSS has also been updated.

This change fixes the visual misalignment between the two views.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a header in the Claims view with a search bar and an “Upload Claims” button that opens a modal.
- Style
  - Updated Claims view container with padding and a light gray background.
  - Consolidated layout so the Claims view begins with stats and the table (previous inline header removed).
  - Adjusted dashboard grid: Claims view no longer spans full width; insights panel remains in the right column.
- Bug Fixes
  - Improved layout consistency between Dashboard and Claims views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->