### PR TITLE
fix(layout): Adjust dashboard grid to a 2x2 layout

### DIFF
--- a/Kuve-AKU-1/src/components/Dashboard.css
+++ b/Kuve-AKU-1/src/components/Dashboard.css
@@ -177,12 +177,7 @@
 
 .dashboard-grid {
   display: grid;
-  grid-template-columns: 1fr 2fr; /* 1fr for the left column, 2fr for the right */
+  grid-template-columns: repeat(2, 1fr);
   gap: 24px;
   align-items: start;
 }
-
-.grid-item-alert { grid-column: 1 / 2; }
-.grid-item-overview { grid-column: 2 / 3; }
-.grid-item-activity { grid-column: 1 / 2; }
-.grid-item-insights { grid-column: 2 / 3; }


### PR DESCRIPTION
The previous dashboard layout was using a 1fr 2fr grid, which caused the components to be clustered. This change adjusts the grid to be an equal 2-column layout and removes explicit grid placements to allow for a natural flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Dashboard to a two-column, equal-width grid for a more balanced and predictable layout.
  * Removed fixed column placements so cards flow naturally, improving consistency across alerts, overview, activity, and insights sections.
  * Preserved spacing and alignment for a clean, organized look.
  * Enhances responsiveness and visual harmony across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->