### PR TITLE
feat: Update Claims Management page styling

### DIFF
--- a/Kuve-AKU-1/src/components/ClaimsManagement.css
+++ b/Kuve-AKU-1/src/components/ClaimsManagement.css
@@ -41,29 +41,31 @@
   border: 1px solid var(--border);
   border-radius: 12px;
   padding: 16px;
-  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
+  background-color: var(--background);
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
   display: flex;
   align-items: center;
+  gap: 16px;
 }
 
-.stat-card.claims { background-color: #F5F3FF; }
-.stat-card.in-process { background-color: #EFF6FF; }
-.stat-card.needs-review { background-color: #FFFBEB; }
-.stat-card.approved-sent { background-color: #F0FDF4; }
-.stat-card.resubmission { background-color: #F0FDF4; }
-.stat-card.appeal { background-color: #FEF2F2; }
+.stat-card.claims .stat-card-icon-container { background-color: #F5F3FF; }
+.stat-card.in-process .stat-card-icon-container { background-color: #EFF6FF; }
+.stat-card.needs-review .stat-card-icon-container { background-color: #FFFBEB; }
+.stat-card.approved-sent .stat-card-icon-container { background-color: #F0FDF4; }
+.stat-card.resubmission .stat-card-icon-container { background-color: #F0FDF4; }
+.stat-card.appeal .stat-card-icon-container { background-color: #FEF2F2; }
 
 
 .card-content {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 16px;
 }
 
 .stat-card-icon-container {
-  width: 36px;
-  height: 36px;
-  border-radius: 6px;
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -75,65 +77,35 @@
   height: 20px;
 }
 
-.stat-card-icon.claims { color: var(--purple); }
-.stat-card-icon.in-process { color: var(--blue); }
-.stat-card-icon.needs-review { color: var(--orange); }
-.stat-card-icon.approved-sent { color: var(--green); }
-.stat-card-icon.resubmission { color: var(--green); }
-.stat-card-icon.appeal { color: var(--red); }
+.stat-card-icon.claims { color: #8B5CF6; }
+.stat-card-icon.in-process { color: #3B82F6; }
+.stat-card-icon.needs-review { color: #F59E0B; }
+.stat-card-icon.approved-sent { color: #10B981; }
+.stat-card-icon.resubmission { color: #10B981; }
+.stat-card-icon.appeal { color: #EF4444; }
 
-.stat-card-main-number {
-  font-size: 24px;
-  font-weight: 700;
-  margin: 0;
-}
-
-.stat-card-main-number.claims,
-.stat-card.claims .stat-card-label,
-.stat-card.claims .stat-card-subtext {
-  color: var(--purple);
-}
-
-.stat-card-main-number.in-process,
-.stat-card.in-process .stat-card-label,
-.stat-card.in-process .stat-card-subtext {
-  color: var(--blue);
-}
-
-.stat-card-main-number.needs-review,
-.stat-card.needs-review .stat-card-label,
-.stat-card.needs-review .stat-card-subtext {
-  color: var(--orange);
-}
-
-.stat-card-main-number.approved-sent,
-.stat-card.approved-sent .stat-card-label,
-.stat-card.approved-sent .stat-card-subtext {
-  color: var(--green);
-}
-
-.stat-card-main-number.resubmission,
-.stat-card.resubmission .stat-card-label,
-.stat-card.resubmission .stat-card-subtext {
-  color: var(--green);
-}
-
-.stat-card-main-number.appeal,
-.stat-card.appeal .stat-card-label,
-.stat-card.appeal .stat-card-subtext {
-  color: var(--red);
+.card-info {
+  display: flex;
+  flex-direction: column;
 }
 
 .stat-card-label {
   font-size: 14px;
-  font-weight: 500; /* Medium */
+  font-weight: 500;
   color: var(--secondary-text);
+  margin: 0;
+}
+
+.stat-card-main-number {
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--primary-text);
   margin: 4px 0;
 }
 
 .stat-card-subtext {
   font-size: 12px;
-  color: var(--tertiary-text);
+  color: var(--secondary-text);
   margin: 0;
 }
 
@@ -157,85 +129,52 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px 16px;
+  padding: 16px 20px;
   border-bottom: 1px solid var(--border);
   background-color: var(--background);
-  border-top-left-radius: 12px;
-  border-top-right-radius: 12px;
 }
 
 .tabs {
   display: flex;
-  gap: 4px;
-  flex-shrink: 1;
-  overflow-x: auto;
-  padding-bottom: 8px; /* Space for a more substantial scrollbar */
-  scrollbar-width: thin;
-  scrollbar-color: var(--blue-border-active) var(--light-gray-bg);
-}
-
-/* Themed Scrollbar for Webkit browsers (Chrome, Safari, etc.) */
-.tabs::-webkit-scrollbar {
-  height: 8px;
-}
-
-.tabs::-webkit-scrollbar-track {
-  background-color: var(--light-gray-bg);
-  border-radius: 4px;
-}
-
-.tabs::-webkit-scrollbar-thumb {
-  background-color: var(--blue-border-active);
-  border-radius: 4px;
-  border: 2px solid var(--light-gray-bg); /* Creates a padding effect */
-}
-
-.tabs::-webkit-scrollbar-thumb:hover {
-  background-color: var(--blue);
+  gap: 8px;
 }
 
 .table-actions {
-  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .tab-button {
-  padding: 8px 16px;
+  padding: 8px 12px;
   font-size: 14px;
-  font-weight: 500; /* Medium */
-  border: 1px solid transparent;
+  font-weight: 500;
+  border: none;
   border-radius: 8px;
   cursor: pointer;
   background-color: transparent;
   color: var(--secondary-text);
   transition: all 0.2s ease-in-out;
+  border-bottom: 2px solid transparent;
 }
 
 .tab-button.active {
-  background-color: var(--light-blue-active-tab);
-  border: 1px solid var(--blue-border-active);
-  color: var(--blue-text-active);
+  color: var(--blue);
+  border-bottom: 2px solid var(--blue);
 }
 
 .tab-button:not(.active):hover {
   background-color: var(--hover-tint);
 }
 
-.table-actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
 .table-search-bar {
   display: flex;
   align-items: center;
-  background-color: var(--background);
+  background-color: var(--light-gray-bg);
   border: 1px solid var(--border);
   border-radius: 8px;
-  padding: 8px; /* 6px vertical + 1px border = ~8px */
-  width: 200px;
-  height: 36px;
-  margin-left: 16px;
+  padding: 8px 12px;
+  width: 220px;
 }
 
 .table-search-bar .search-icon {
@@ -293,42 +232,22 @@
 .claims-table {
   width: 100%;
   border-collapse: collapse;
-  table-layout: fixed; /* Critical for fixed column widths */
 }
 
-/* Typography and Padding Adjustments per spec */
 .claims-table th,
 .claims-table td {
-  padding: 6px 8px; /* 6px vertical, 8px horizontal */
+  padding: 12px 16px;
   text-align: left;
   vertical-align: middle;
-  font-size: 13px; /* Reduced from 14px */
-  line-height: 18px; /* Reduced from 20px */
-  word-wrap: break-word;
+  font-size: 14px;
+  white-space: nowrap;
 }
 
 .claims-table th {
-  font-weight: 500; /* Medium */
+  font-weight: 500;
   color: var(--secondary-text);
   background-color: var(--light-gray-bg);
-  white-space: nowrap;
-  font-size: 13px; /* Matching cell font size */
 }
-
-/* --- CRITICAL: Column Widths (Adjusted for fit) --- */
-.th-claim-id { width: 120px; }
-.th-customer { width: 140px; }
-.th-provider { width: 120px; }
-.th-payer { width: 110px; }
-.th-date-issued { width: 140px; }
-.th-amount { width: 90px; }
-.th-status { width: 120px; }
-.th-actions { width: 60px; }
-
-/* Alignment per spec */
-.claims-table th.th-amount, .claims-table td.amount { text-align: right; }
-.claims-table th.th-status, .claims-table td.status-cell { text-align: center; }
-.claims-table th.th-actions, .claims-table td.actions-cell { text-align: center; }
 
 .claims-table thead tr {
   border-bottom: 1px solid var(--border);
@@ -336,72 +255,70 @@
 
 .claims-table tbody tr {
   border-bottom: 1px solid var(--border);
-  min-height: 56px; /* Maintain minimum row height */
 }
+
 .claims-table tbody tr:last-child {
   border-bottom: none;
 }
 
 .claims-table tbody tr:nth-child(even) {
+  background-color: #FFFFFF;
+}
+
+.claims-table tbody tr:nth-child(odd) {
   background-color: var(--light-gray-bg);
 }
 
 .claims-table td {
   color: var(--primary-text);
-  white-space: normal;
 }
 
 .claim-id {
   font-family: monospace;
 }
 
-/* Pill Badge Optimization per spec */
 .pill-badge {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 6px;
-  border: 1px solid #D1D5DB;
-  border-radius: 6px;
-  background-color: #F3F4F6;
+  padding: 4px 10px;
+  border-radius: 16px;
   font-size: 12px;
-  color: #4B5563;
-  line-height: 1.4;
-  white-space: normal; /* Allow soft wrapping */
-  max-width: 100%;
-  word-break: break-word; /* Allow long text to wrap */
+  font-weight: 500;
+}
+
+.pill-badge.provider {
+  background-color: #E0E7FF;
+  color: #4338CA;
+}
+
+.pill-badge.payer {
+  background-color: #DBEAFE;
+  color: #1E40AF;
 }
 
 .pill-badge .pill-icon {
-  width: 12px;
-  height: 12px;
-  color: #9CA3AF;
-  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
 }
 
 .date-issued {
   color: var(--secondary-text);
 }
 
-/* Amount & Status Optimization */
-.claims-table .amount {
-  font-weight: 700; /* Bold */
+.amount {
+  font-weight: 500;
   color: var(--green);
-  font-size: 14px; /* Keep font size for emphasis */
-  font-family: monospace; /* For alignment */
 }
 
 .status-badge {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 6px; /* Reduced padding */
-  border-radius: 6px;
+  padding: 4px 10px;
+  border-radius: 16px;
   font-size: 12px;
   font-weight: 500;
-  white-space: normal; /* Allow soft wrap */
-  line-height: 1.4;
-  max-width: 100%;
 }
 
 .status-badge .status-icon {

--- a/Kuve-AKU-1/src/components/ClaimsManagement.tsx
+++ b/Kuve-AKU-1/src/components/ClaimsManagement.tsx
@@ -137,13 +137,13 @@ const ClaimsManagement = () => {
                 <td className="claim-id">AKU-2025-627</td>
                 <td>Raul Sampson</td>
                 <td>
-                  <div className="pill-badge">
+                  <div className="pill-badge provider">
                     <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" /></svg>
                     LASUTH
                   </div>
                 </td>
                 <td>
-                  <div className="pill-badge">
+                  <div className="pill-badge payer">
                     <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 20.944a11.955 11.955 0 0118-8.944c0-2.21-.8-4.24-2.144-5.882z" /></svg>
                     BlueCross
                   </div>
@@ -160,18 +160,45 @@ const ClaimsManagement = () => {
                   <svg className="actions-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" /></svg>
                 </td>
               </tr>
-              {/* Row 2 */}
+              {/* Additional Rows */}
+              <tr>
+                <td className="claim-id">AKU-2025-526</td>
+                <td>Morgan Alex</td>
+                <td>
+                  <div className="pill-badge provider">
+                    <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" /></svg>
+                    UCH
+                  </div>
+                </td>
+                <td>
+                  <div className="pill-badge payer">
+                    <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 20.944a11.955 11.955 0 0118-8.944c0-2.21-.8-4.24-2.144-5.882z" /></svg>
+                    Tinsured
+                  </div>
+                </td>
+                <td className="date-issued">08-03-2025 22:18</td>
+                <td className="amount">$8,373</td>
+                <td className="status-cell">
+                  <div className="status-badge in-process">
+                    <svg className="status-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+                    In Process
+                  </div>
+                </td>
+                <td className="actions-cell">
+                  <svg className="actions-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" /></svg>
+                </td>
+              </tr>
               <tr>
                 <td className="claim-id">AKU-2025-112</td>
                 <td>Barrett Marks</td>
                 <td>
-                  <div className="pill-badge">
-                   <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" /></svg>
+                  <div className="pill-badge provider">
+                    <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" /></svg>
                     OAUTH
                   </div>
                 </td>
                 <td>
-                  <div className="pill-badge">
+                  <div className="pill-badge payer">
                     <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 20.944a11.955 11.955 0 0118-8.944c0-2.21-.8-4.24-2.144-5.882z" /></svg>
                     AIICO
                   </div>
@@ -185,21 +212,74 @@ const ClaimsManagement = () => {
                   </div>
                 </td>
                 <td className="actions-cell">
-                   <svg className="actions-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" /></svg>
+                  <svg className="actions-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" /></svg>
                 </td>
               </tr>
-                {/* Row 3 */}
+              <tr>
+                <td className="claim-id">AKU-2025-334</td>
+                <td>Orlando Tillman</td>
+                <td>
+                  <div className="pill-badge provider">
+                    <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" /></svg>
+                    OAUTH
+                  </div>
+                </td>
+                <td>
+                  <div className="pill-badge payer">
+                    <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 20.944a11.955 11.955 0 0118-8.944c0-2.21-.8-4.24-2.144-5.882z" /></svg>
+                    AIICO
+                  </div>
+                </td>
+                <td className="date-issued">06-05-2025 07:49</td>
+                <td className="amount">$3,625</td>
+                <td className="status-cell">
+                  <div className="status-badge needs-review">
+                    <svg className="status-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
+                    Needs Review
+                  </div>
+                </td>
+                <td className="actions-cell">
+                  <svg className="actions-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" /></svg>
+                </td>
+              </tr>
+              <tr>
+                <td className="claim-id">AKU-2025-121</td>
+                <td>Sidney Ramos</td>
+                <td>
+                  <div className="pill-badge provider">
+                    <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" /></svg>
+                    OAUTH
+                  </div>
+                </td>
+                <td>
+                  <div className="pill-badge payer">
+                    <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 20.944a11.955 11.955 0 0118-8.944c0-2.21-.8-4.24-2.144-5.882z" /></svg>
+                    AIICO
+                  </div>
+                </td>
+                <td className="date-issued">14-06-2025 19:08</td>
+                <td className="amount">$7,752</td>
+                <td className="status-cell">
+                  <div className="status-badge needs-review">
+                    <svg className="status-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
+                    Needs Review
+                  </div>
+                </td>
+                <td className="actions-cell">
+                  <svg className="actions-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" /></svg>
+                </td>
+              </tr>
               <tr>
                 <td className="claim-id">AKU-2025-004</td>
                 <td>Corey Owen</td>
                 <td>
-                  <div className="pill-badge">
+                  <div className="pill-badge provider">
                     <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" /></svg>
                     LANDMARK
                   </div>
                 </td>
                 <td>
-                  <div className="pill-badge">
+                  <div className="pill-badge payer">
                     <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 20.944a11.955 11.955 0 0118-8.944c0-2.21-.8-4.24-2.144-5.882z" /></svg>
                     AIICO
                   </div>
@@ -213,7 +293,88 @@ const ClaimsManagement = () => {
                   </div>
                 </td>
                 <td className="actions-cell">
-                   <svg className="actions-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" /></svg>
+                  <svg className="actions-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" /></svg>
+                </td>
+              </tr>
+              <tr>
+                <td className="claim-id">AKU-2025-672</td>
+                <td>Orlando Horne</td>
+                <td>
+                  <div className="pill-badge provider">
+                    <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" /></svg>
+                    LANDMARK
+                  </div>
+                </td>
+                <td>
+                  <div className="pill-badge payer">
+                    <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 20.944a11.955 11.955 0 0118-8.944c0-2.21-.8-4.24-2.144-5.882z" /></svg>
+                    AIICO
+                  </div>
+                </td>
+                <td className="date-issued">11-09-2025 13:11</td>
+                <td className="amount">$7,728</td>
+                <td className="status-cell">
+                  <div className="status-badge approved-sent">
+                    <svg className="status-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+                    Approved & Sent
+                  </div>
+                </td>
+                <td className="actions-cell">
+                  <svg className="actions-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" /></svg>
+                </td>
+              </tr>
+              <tr>
+                <td className="claim-id">AKU-2025-009</td>
+                <td>Brittany Price</td>
+                <td>
+                  <div className="pill-badge provider">
+                    <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" /></svg>
+                    LANDMARK
+                  </div>
+                </td>
+                <td>
+                  <div className="pill-badge payer">
+                    <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 20.944a11.955 11.955 0 0118-8.944c0-2.21-.8-4.24-2.144-5.882z" /></svg>
+                    AIICO
+                  </div>
+                </td>
+                <td className="date-issued">13-09-2025 13:11</td>
+                <td className="amount">$9,027</td>
+                <td className="status-cell">
+                  <div className="status-badge approved-sent">
+                    <svg className="status-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+                    Approved & Sent
+                  </div>
+                </td>
+                <td className="actions-cell">
+                  <svg className="actions-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" /></svg>
+                </td>
+              </tr>
+              <tr>
+                <td className="claim-id">AKU-2025-1431</td>
+                <td>Carlie Chandler</td>
+                <td>
+                  <div className="pill-badge provider">
+                    <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" /></svg>
+                    UNILAGTH
+                  </div>
+                </td>
+                <td>
+                  <div className="pill-badge payer">
+                    <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 20.944a11.955 11.955 0 0118-8.944c0-2.21-.8-4.24-2.144-5.882z" /></svg>
+                    AXA
+                  </div>
+                </td>
+                <td className="date-issued">18-12-2025 12:52</td>
+                <td className="amount">$8,215</td>
+                <td className="status-cell">
+                  <div className="status-badge approved-sent">
+                    <svg className="status-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+                    Approved & Sent
+                  </div>
+                </td>
+                <td className="actions-cell">
+                  <svg className="actions-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" /></svg>
                 </td>
               </tr>
             </tbody>

--- a/Kuve-AKU-1/src/components/Dashboard.css
+++ b/Kuve-AKU-1/src/components/Dashboard.css
@@ -150,23 +150,71 @@
   margin-top: 4px;
 }
 
-.timeframe-selector {
+.header-actions {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
+}
+
+.search-bar-header {
+  display: flex;
+  align-items: center;
   background-color: #FFFFFF;
-  padding: 8px 12px;
-  border-radius: 8px;
   border: 1px solid #E5E7EB;
+  border-radius: 8px;
+  padding: 8px 12px;
+  width: 250px;
+  transition: box-shadow 0.2s;
+}
+
+.search-bar-header:focus-within {
+  box-shadow: 0 0 0 2px #A5B4FC;
+  border-color: #6366F1;
+}
+
+.search-bar-header .search-icon {
+  color: #9CA3AF;
+  width: 18px;
+  height: 18px;
+  margin-right: 8px;
+}
+
+.search-bar-header input {
+  border: none;
+  outline: none;
+  background-color: transparent;
+  width: 100%;
+  font-size: 14px;
+  color: #111827;
+}
+
+.search-bar-header input::placeholder {
+  color: #9CA3AF;
+}
+
+.upload-claims-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 9px 16px;
+  background-color: #4F46E5;
+  color: #FFFFFF;
+  border: none;
+  border-radius: 8px;
   font-size: 14px;
   font-weight: 500;
-  color: #374151;
   cursor: pointer;
   transition: background-color 0.2s;
 }
 
-.timeframe-selector:hover {
-  background-color: #F3F4F6;
+.upload-claims-button:hover {
+  background-color: #4338CA;
+}
+
+.upload-claims-button .upload-icon {
+  width: 18px;
+  height: 18px;
 }
 
 .dropdown-icon {

--- a/Kuve-AKU-1/src/components/Dashboard.tsx
+++ b/Kuve-AKU-1/src/components/Dashboard.tsx
@@ -88,7 +88,7 @@ const Dashboard = () => {
                     <h1 className="header-title">Claims Management</h1>
                     <p className="header-subtitle">View and manage all dental claims in detail</p>
                 </div>
-                <div className="timeframe-selector">
+                <div className="header-actions">
                     <div className="search-bar-header">
                         <svg xmlns="http://www.w3.org/2000/svg" className="search-icon" viewBox="0 0 20 20" fill="currentColor">
                             <path fillRule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clipRule="evenodd" />
@@ -96,10 +96,10 @@ const Dashboard = () => {
                         <input type="text" placeholder="Search from Provider" />
                     </div>
                     <button className="upload-claims-button" onClick={handleOpenModal}>
-                        <svg className="upload-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" >
-                            <path d="M10 12.5V3.33331" strokeLinecap="round" strokeLinejoin="round"/>
-                            <path d="M6.66669 6.66669L10 3.33335L13.3334 6.66669" strokeLinecap="round" strokeLinejoin="round"/>
-                            <path d="M16.6667 10V16.6667H3.33331V10" strokeLinecap="round" strokeLinejoin="round"/>
+                        <svg className="upload-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" >
+                            <path d="M10 12.5V3.33331" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                            <path d="M6.66669 6.66669L10 3.33335L13.3334 6.66669" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                            <path d="M16.6667 10V16.6667H3.33331V10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
                         </svg>
                         Upload Claims
                     </button>


### PR DESCRIPTION
This commit updates the styling of the Claims Management page to match the provided design.

The following changes were made:
- Restyled the page header, including the search bar and upload button.
- Updated the styling of the stat cards to match the new design.
- Refined the table tabs and actions to align with the visual target.
- Overhauled the claims table, including header, rows, badges, and fonts.
- Added additional static data to the claims table to better demonstrate the new styles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded claims table content with additional rows and varied provider/payer badge combinations.

- Style
  - Refreshed Claims Management UI: lighter cards, improved spacing, larger icons, clearer status pills, updated typography, alternating row backgrounds, and responsive tweaks.
  - Simplified table layout with clearer actions and refined search/table controls.
  - Updated Dashboard header with a new actions layout, styled search bar, and refined upload button visuals.

- Refactor
  - Consolidated badge classes, shifted status coloring to icon containers, and updated SVGs to use currentColor for consistent theming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->