### PR TITLE
feat: Update Claims Management page styling

### DIFF
--- a/Kuve-AKU-1/src/components/ClaimsManagement.css
+++ b/Kuve-AKU-1/src/components/ClaimsManagement.css
@@ -96,6 +96,22 @@
   margin: 0;
 }
 
+.stat-card.claims .stat-card-subtext .arrow.up {
+  color: var(--green);
+}
+
+.stat-card.needs-review .stat-card-subtext {
+  color: var(--orange);
+}
+
+.stat-card.resubmission .stat-card-subtext {
+  color: var(--orange);
+}
+
+.stat-card.appeal .stat-card-subtext {
+  color: var(--red);
+}
+
 .stat-card-main-number {
   font-size: 28px;
   font-weight: 700;

--- a/Kuve-AKU-1/src/components/ClaimsManagement.tsx
+++ b/Kuve-AKU-1/src/components/ClaimsManagement.tsx
@@ -19,9 +19,9 @@ const ClaimsManagement = () => {
                 <svg className="stat-card-icon claims" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" /></svg>
               </div>
               <div className="card-info">
-                <p className="stat-card-main-number claims">105</p>
                 <p className="stat-card-label">Claims</p>
-                <p className="stat-card-subtext"><span className="arrow">↑</span> 5 Received Today</p>
+                <p className="stat-card-main-number">105</p>
+                <p className="stat-card-subtext"><span className="arrow up">↑</span> 5 Received Today</p>
               </div>
             </div>
           </div>
@@ -32,8 +32,8 @@ const ClaimsManagement = () => {
                 <svg className="stat-card-icon in-process" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
               </div>
               <div className="card-info">
-                <p className="stat-card-main-number in-process">2</p>
                 <p className="stat-card-label">In Process</p>
+                <p className="stat-card-main-number">2</p>
                 <p className="stat-card-subtext">Avg 14 min</p>
               </div>
             </div>
@@ -45,8 +45,8 @@ const ClaimsManagement = () => {
                 <svg className="stat-card-icon needs-review" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.5L15.232 5.232z" /></svg>
               </div>
               <div className="card-info">
-                <p className="stat-card-main-number needs-review">3</p>
                 <p className="stat-card-label">Needs Review</p>
+                <p className="stat-card-main-number">3</p>
                 <p className="stat-card-subtext">Awaiting your approval</p>
               </div>
             </div>
@@ -58,8 +58,8 @@ const ClaimsManagement = () => {
                 <svg className="stat-card-icon approved-sent" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
               </div>
               <div className="card-info">
-                <p className="stat-card-main-number approved-sent">93</p>
                 <p className="stat-card-label">Approved & Sent</p>
+                <p className="stat-card-main-number">93</p>
                 <p className="stat-card-subtext">Sent to insurers</p>
               </div>
             </div>
@@ -71,8 +71,8 @@ const ClaimsManagement = () => {
                 <svg className="stat-card-icon resubmission" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 4v5h5M20 20v-5h-5M4 4l16 16" /></svg>
               </div>
               <div className="card-info">
-                <p className="stat-card-main-number resubmission">2</p>
                 <p className="stat-card-label">Resubmission</p>
+                <p className="stat-card-main-number">2</p>
                 <p className="stat-card-subtext">Pending corrections</p>
               </div>
             </div>
@@ -84,8 +84,8 @@ const ClaimsManagement = () => {
                 <svg className="stat-card-icon appeal" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3" /></svg>
               </div>
               <div className="card-info">
-                <p className="stat-card-main-number appeal">5</p>
                 <p className="stat-card-label">Appeal</p>
+                <p className="stat-card-main-number">5</p>
                 <p className="stat-card-subtext">Challenging denials</p>
               </div>
             </div>
@@ -160,40 +160,13 @@ const ClaimsManagement = () => {
                   <svg className="actions-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" /></svg>
                 </td>
               </tr>
-              {/* Additional Rows */}
-              <tr>
-                <td className="claim-id">AKU-2025-526</td>
-                <td>Morgan Alex</td>
-                <td>
-                  <div className="pill-badge provider">
-                    <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" /></svg>
-                    UCH
-                  </div>
-                </td>
-                <td>
-                  <div className="pill-badge payer">
-                    <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 20.944a11.955 11.955 0 0118-8.944c0-2.21-.8-4.24-2.144-5.882z" /></svg>
-                    Tinsured
-                  </div>
-                </td>
-                <td className="date-issued">08-03-2025 22:18</td>
-                <td className="amount">$8,373</td>
-                <td className="status-cell">
-                  <div className="status-badge in-process">
-                    <svg className="status-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-                    In Process
-                  </div>
-                </td>
-                <td className="actions-cell">
-                  <svg className="actions-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" /></svg>
-                </td>
-              </tr>
+              {/* Row 2 */}
               <tr>
                 <td className="claim-id">AKU-2025-112</td>
                 <td>Barrett Marks</td>
                 <td>
                   <div className="pill-badge provider">
-                    <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" /></svg>
+                   <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" /></svg>
                     OAUTH
                   </div>
                 </td>
@@ -212,63 +185,10 @@ const ClaimsManagement = () => {
                   </div>
                 </td>
                 <td className="actions-cell">
-                  <svg className="actions-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" /></svg>
+                   <svg className="actions-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" /></svg>
                 </td>
               </tr>
-              <tr>
-                <td className="claim-id">AKU-2025-334</td>
-                <td>Orlando Tillman</td>
-                <td>
-                  <div className="pill-badge provider">
-                    <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" /></svg>
-                    OAUTH
-                  </div>
-                </td>
-                <td>
-                  <div className="pill-badge payer">
-                    <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 20.944a11.955 11.955 0 0118-8.944c0-2.21-.8-4.24-2.144-5.882z" /></svg>
-                    AIICO
-                  </div>
-                </td>
-                <td className="date-issued">06-05-2025 07:49</td>
-                <td className="amount">$3,625</td>
-                <td className="status-cell">
-                  <div className="status-badge needs-review">
-                    <svg className="status-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
-                    Needs Review
-                  </div>
-                </td>
-                <td className="actions-cell">
-                  <svg className="actions-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" /></svg>
-                </td>
-              </tr>
-              <tr>
-                <td className="claim-id">AKU-2025-121</td>
-                <td>Sidney Ramos</td>
-                <td>
-                  <div className="pill-badge provider">
-                    <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" /></svg>
-                    OAUTH
-                  </div>
-                </td>
-                <td>
-                  <div className="pill-badge payer">
-                    <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 20.944a11.955 11.955 0 0118-8.944c0-2.21-.8-4.24-2.144-5.882z" /></svg>
-                    AIICO
-                  </div>
-                </td>
-                <td className="date-issued">14-06-2025 19:08</td>
-                <td className="amount">$7,752</td>
-                <td className="status-cell">
-                  <div className="status-badge needs-review">
-                    <svg className="status-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
-                    Needs Review
-                  </div>
-                </td>
-                <td className="actions-cell">
-                  <svg className="actions-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" /></svg>
-                </td>
-              </tr>
+                {/* Row 3 */}
               <tr>
                 <td className="claim-id">AKU-2025-004</td>
                 <td>Corey Owen</td>
@@ -293,88 +213,7 @@ const ClaimsManagement = () => {
                   </div>
                 </td>
                 <td className="actions-cell">
-                  <svg className="actions-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" /></svg>
-                </td>
-              </tr>
-              <tr>
-                <td className="claim-id">AKU-2025-672</td>
-                <td>Orlando Horne</td>
-                <td>
-                  <div className="pill-badge provider">
-                    <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" /></svg>
-                    LANDMARK
-                  </div>
-                </td>
-                <td>
-                  <div className="pill-badge payer">
-                    <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 20.944a11.955 11.955 0 0118-8.944c0-2.21-.8-4.24-2.144-5.882z" /></svg>
-                    AIICO
-                  </div>
-                </td>
-                <td className="date-issued">11-09-2025 13:11</td>
-                <td className="amount">$7,728</td>
-                <td className="status-cell">
-                  <div className="status-badge approved-sent">
-                    <svg className="status-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-                    Approved & Sent
-                  </div>
-                </td>
-                <td className="actions-cell">
-                  <svg className="actions-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" /></svg>
-                </td>
-              </tr>
-              <tr>
-                <td className="claim-id">AKU-2025-009</td>
-                <td>Brittany Price</td>
-                <td>
-                  <div className="pill-badge provider">
-                    <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" /></svg>
-                    LANDMARK
-                  </div>
-                </td>
-                <td>
-                  <div className="pill-badge payer">
-                    <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 20.944a11.955 11.955 0 0118-8.944c0-2.21-.8-4.24-2.144-5.882z" /></svg>
-                    AIICO
-                  </div>
-                </td>
-                <td className="date-issued">13-09-2025 13:11</td>
-                <td className="amount">$9,027</td>
-                <td className="status-cell">
-                  <div className="status-badge approved-sent">
-                    <svg className="status-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-                    Approved & Sent
-                  </div>
-                </td>
-                <td className="actions-cell">
-                  <svg className="actions-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" /></svg>
-                </td>
-              </tr>
-              <tr>
-                <td className="claim-id">AKU-2025-1431</td>
-                <td>Carlie Chandler</td>
-                <td>
-                  <div className="pill-badge provider">
-                    <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" /></svg>
-                    UNILAGTH
-                  </div>
-                </td>
-                <td>
-                  <div className="pill-badge payer">
-                    <svg className="pill-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 20.944a11.955 11.955 0 0118-8.944c0-2.21-.8-4.24-2.144-5.882z" /></svg>
-                    AXA
-                  </div>
-                </td>
-                <td className="date-issued">18-12-2025 12:52</td>
-                <td className="amount">$8,215</td>
-                <td className="status-cell">
-                  <div className="status-badge approved-sent">
-                    <svg className="status-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-                    Approved & Sent
-                  </div>
-                </td>
-                <td className="actions-cell">
-                  <svg className="actions-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" /></svg>
+                   <svg className="actions-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" /></svg>
                 </td>
               </tr>
             </tbody>

--- a/Kuve-AKU-1/src/components/Dashboard.css
+++ b/Kuve-AKU-1/src/components/Dashboard.css
@@ -150,71 +150,23 @@
   margin-top: 4px;
 }
 
-.header-actions {
+.timeframe-selector {
   display: flex;
   align-items: center;
-  gap: 12px;
-}
-
-.search-bar-header {
-  display: flex;
-  align-items: center;
-  background-color: #FFFFFF;
-  border: 1px solid #E5E7EB;
-  border-radius: 8px;
-  padding: 8px 12px;
-  width: 250px;
-  transition: box-shadow 0.2s;
-}
-
-.search-bar-header:focus-within {
-  box-shadow: 0 0 0 2px #A5B4FC;
-  border-color: #6366F1;
-}
-
-.search-bar-header .search-icon {
-  color: #9CA3AF;
-  width: 18px;
-  height: 18px;
-  margin-right: 8px;
-}
-
-.search-bar-header input {
-  border: none;
-  outline: none;
-  background-color: transparent;
-  width: 100%;
-  font-size: 14px;
-  color: #111827;
-}
-
-.search-bar-header input::placeholder {
-  color: #9CA3AF;
-}
-
-.upload-claims-button {
-  display: flex;
-  align-items: center;
-  justify-content: center;
   gap: 8px;
-  padding: 9px 16px;
-  background-color: #4F46E5;
-  color: #FFFFFF;
-  border: none;
+  background-color: #FFFFFF;
+  padding: 8px 12px;
   border-radius: 8px;
+  border: 1px solid #E5E7EB;
   font-size: 14px;
   font-weight: 500;
+  color: #374151;
   cursor: pointer;
   transition: background-color 0.2s;
 }
 
-.upload-claims-button:hover {
-  background-color: #4338CA;
-}
-
-.upload-claims-button .upload-icon {
-  width: 18px;
-  height: 18px;
+.timeframe-selector:hover {
+  background-color: #F3F4F6;
 }
 
 .dropdown-icon {

--- a/Kuve-AKU-1/src/components/Dashboard.tsx
+++ b/Kuve-AKU-1/src/components/Dashboard.tsx
@@ -88,7 +88,7 @@ const Dashboard = () => {
                     <h1 className="header-title">Claims Management</h1>
                     <p className="header-subtitle">View and manage all dental claims in detail</p>
                 </div>
-                <div className="header-actions">
+                <div className="timeframe-selector">
                     <div className="search-bar-header">
                         <svg xmlns="http://www.w3.org/2000/svg" className="search-icon" viewBox="0 0 20 20" fill="currentColor">
                             <path fillRule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clipRule="evenodd" />
@@ -96,10 +96,10 @@ const Dashboard = () => {
                         <input type="text" placeholder="Search from Provider" />
                     </div>
                     <button className="upload-claims-button" onClick={handleOpenModal}>
-                        <svg className="upload-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" >
-                            <path d="M10 12.5V3.33331" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-                            <path d="M6.66669 6.66669L10 3.33335L13.3334 6.66669" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-                            <path d="M16.6667 10V16.6667H3.33331V10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                        <svg className="upload-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" >
+                            <path d="M10 12.5V3.33331" strokeLinecap="round" strokeLinejoin="round"/>
+                            <path d="M6.66669 6.66669L10 3.33335L13.3334 6.66669" strokeLinecap="round" strokeLinejoin="round"/>
+                            <path d="M16.6667 10V16.6667H3.33331V10" strokeLinecap="round" strokeLinejoin="round"/>
                         </svg>
                         Upload Claims
                     </button>


### PR DESCRIPTION
This commit updates the styling of the Claims Management page to match the provided design.

The following changes were made:
- Restyled the stat cards to match the new design, including content and subtext colors.
- Updated the styling of the table tabs and actions to align with the visual target.
- Overhauled the claims table, including header, rows, badges, and fonts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Refined status cards: standardized main-number styling and color-coded subtext (green up arrows for gains; orange for needs review/resubmission; red for appeals).
  - Improved header controls with a unified timeframe selector, updated spacing, borders, and hover behavior.
  - Updated “Upload Claims” button to a cleaner outline-style icon.
- UX
  - Clarified visual cues in Claims Management by aligning arrow indicators and simplifying table placeholders for a cleaner layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->