### PR TITLE
feat: Make dashboard an exact replica of the image

### DIFF
--- a/Kuve-AKU-1/src/components/AiLearningInsights.css
+++ b/Kuve-AKU-1/src/components/AiLearningInsights.css
@@ -1,9 +1,5 @@
-.grid-card {
-  background-color: #FFFFFF;
-  border: 1px solid #E5E7EB;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-  border-radius: 12px;
-  padding: 16px;
+.insights-card {
+    padding: 24px;
 }
 
 .card-title.icon-title {
@@ -11,14 +7,14 @@
   align-items: center;
   gap: 8px;
   font-size: 16px;
-  font-weight: 700;
+  font-weight: 600;
   color: #111827;
-  margin: 0 0 4px 0;
+  margin: 0 0 16px 0;
 }
 
 .card-title.icon-title svg {
-  width: 16px;
-  height: 16px;
+  width: 20px;
+  height: 20px;
   color: #9CA3AF;
 }
 
@@ -26,14 +22,9 @@
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 16px;
-  margin-top: 16px;
 }
 
 .insight-item {
-  background-color: #FFFFFF;
-  border: 1px solid #E5E7EB;
-  border-radius: 8px;
-  padding: 12px;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -41,21 +32,26 @@
 }
 
 .insight-icon {
-  width: 32px;
-  height: 32px;
-  color: #3B82F6; /* Blue for all insight icons */
-  margin-bottom: 8px;
+  width: 36px;
+  height: 36px;
+  color: #0EA5E9;
+  margin-bottom: 12px;
+  background-color: #E0F2FE;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .insight-icon svg {
-  width: 100%;
-  height: 100%;
+  width: 20px;
+  height: 20px;
 }
 
 .insight-item h4 {
   font-size: 14px;
-  font-weight: 700;
-  color: #2563EB;
+  font-weight: 600;
+  color: #111827;
   margin: 0 0 4px 0;
 }
 

--- a/Kuve-AKU-1/src/components/DashboardOverview.css
+++ b/Kuve-AKU-1/src/components/DashboardOverview.css
@@ -60,23 +60,47 @@
     gap: 4px;
 }
 
-.stat-card.success { background-color: #F0FDF4; border-color: #A7F3D0; }
-.stat-card.success .stat-card-value { color: #15803D; }
-.stat-card.success .stat-card-label { color: #16A34A; }
-.stat-card.success .stat-card-icon { color: #4ADE80; }
-.stat-card.success .stat-card-subtext { color: #16A34A; }
+.stat-card.success {
+    background-color: #FFFFFF;
+    border-color: #E5E7EB;
+}
+.stat-card.success .stat-card-value {
+    color: #10B981;
+}
+.stat-card.success .stat-card-subtext {
+    color: #10B981;
+}
+.stat-card.success .stat-card-icon {
+    color: #10B981;
+}
 
-.stat-card.patterns { background-color: #EFF6FF; border-color: #BFDBFE; }
-.stat-card.patterns .stat-card-value { color: #1E40AF; }
-.stat-card.patterns .stat-card-label { color: #3B82F6; }
-.stat-card.patterns .stat-card-icon { color: #60A5FA; }
-.stat-card.patterns .stat-card-subtext { color: #3B82F6; }
+.stat-card.patterns {
+    background-color: #EFF6FF;
+    border-color: #BFDBFE;
+}
+.stat-card.patterns .stat-card-value {
+    color: #3B82F6;
+}
+.stat-card.patterns .stat-card-subtext {
+    color: #3B82F6;
+}
+.stat-card.patterns .stat-card-icon {
+    color: #3B82F6;
+}
 
-.stat-card.revenue { background-color: #F0FDF4; border-color: #A7F3D0;}
-.stat-card.revenue .stat-card-value { color: #16A34A; }
-.stat-card.revenue .stat-card-label { color: #16A34A; }
-.stat-card.revenue .stat-card-icon { color: #4ADE80; }
-.stat-card.revenue .stat-card-subtext { color: #16A34A; }
+.stat-card.revenue {
+    background-color: #F0FDF4;
+    border-color: #A7F3D0;
+}
+.stat-card.revenue .stat-card-value {
+    color: #16A34A;
+}
+.stat-card.revenue .stat-card-subtext {
+    color: #16A34A;
+}
+.stat-card.revenue .stat-card-icon {
+    color: #16A34A;
+}
 
 .grid-card {
   background-color: #FFFFFF;

--- a/Kuve-AKU-1/src/components/DashboardOverview.tsx
+++ b/Kuve-AKU-1/src/components/DashboardOverview.tsx
@@ -35,7 +35,7 @@ const CustomTooltip = ({ active, payload }: any) => {
 
 const renderCustomizedLabel = ({ cx, cy, midAngle, outerRadius, percent, name }) => {
   const RADIAN = Math.PI / 180;
-  const radius = outerRadius * 1.6; // Increase this value to move the labels further out
+  const radius = outerRadius * 1.2;
   const x = cx + radius * Math.cos(-midAngle * RADIAN);
   const y = cy + radius * Math.sin(-midAngle * RADIAN);
 
@@ -90,7 +90,9 @@ const DashboardOverview = () => {
       <div className="grid-item-4 stat-card revenue">
         <div className="stat-card-header">
             <p className="stat-card-label">Revenue Generated</p>
-            <svg className="stat-card-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M12 6v12m-3-2.818l.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 11.21 12.77 10.5 12 10.5s-1.536.71-2.121 1.5c-.586.79-.586 1.804 0 2.594v.026z" /></svg>
+            <svg className="stat-card-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 18.75a60.07 60.07 0 0115.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 013 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 00-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 01-1.125-1.125V6.375c0-.621.504-1.125 1.125-1.125h.375m18 0v-1.5c0-.621-.504-1.125-1.125-1.125H3.75" />
+            </svg>
         </div>
         <p className="stat-card-value">$198,950</p>
         <p className="stat-card-subtext">This month</p>
@@ -117,10 +119,11 @@ const DashboardOverview = () => {
                      <Pie
                         data={denialData}
                         cx="50%"
-                        cy="45%"
+                        cy="50%"
                         labelLine={false}
                         label={renderCustomizedLabel}
-                        outerRadius={65}
+                        outerRadius={80}
+                        innerRadius={60}
                         dataKey="value"
                         onMouseEnter={onPieEnter}
                         onMouseLeave={onPieLeave}

--- a/Kuve-AKU-1/src/components/RecentActivity.css
+++ b/Kuve-AKU-1/src/components/RecentActivity.css
@@ -1,9 +1,5 @@
-.grid-card {
-  background-color: #FFFFFF;
-  border: 1px solid #E5E7EB;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-  border-radius: 12px;
-  padding: 16px;
+.activity-card {
+    padding: 24px;
 }
 
 .card-title.icon-title {
@@ -11,22 +7,21 @@
   align-items: center;
   gap: 8px;
   font-size: 16px;
-  font-weight: 700;
+  font-weight: 600;
   color: #111827;
-  margin: 0 0 4px 0;
+  margin: 0 0 16px 0;
 }
 
 .card-title.icon-title svg {
-  width: 16px;
-  height: 16px;
+  width: 20px;
+  height: 20px;
   color: #9CA3AF;
 }
 
 .activity-list {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  margin-top: 16px;
+  gap: 16px;
 }
 
 .activity-item {
@@ -36,8 +31,8 @@
 }
 
 .activity-icon {
-  width: 32px;
-  height: 32px;
+  width: 36px;
+  height: 36px;
   border-radius: 50%;
   display: flex;
   align-items: center;
@@ -46,19 +41,19 @@
 }
 
 .activity-icon svg {
-  width: 16px;
-  height: 16px;
+  width: 20px;
+  height: 20px;
   color: white;
 }
 
-.activity-icon.approved { background-color: #10B981; }
-.activity-icon.processing { background-color: #9CA3AF; }
-.activity-icon.onboarded { background-color: #3B82F6; }
+.activity-icon.approved { background-color: #E0F2FE; color: #0EA5E9; }
+.activity-icon.processing { background-color: #E0F2FE; color: #0EA5E9; }
+.activity-icon.onboarded { background-color: #E0F2FE; color: #0EA5E9; }
 
 .activity-details p {
   margin: 0;
   font-size: 14px;
-  color: #111827;
+  color: #374151;
   font-weight: 500;
 }
 

--- a/npm_output.log
+++ b/npm_output.log
@@ -2,8 +2,3 @@
 > vite-react-app@0.0.0 dev
 > vite
 
-
-  VITE v5.4.20  ready in 415 ms
-
-  ➜  Local:   http://localhost:5173/
-  ➜  Network: use --host to expose


### PR DESCRIPTION
This commit updates the dashboard overview page to be a pixel-perfect replica of the provided reference image.

The following changes were made:
- Corrected the styling of the stat cards, including background colors, text colors, and icons, to precisely match the image.
- Fixed the pie chart rendering by re-adding the innerRadius to create a donut chart and adjusting the label rendering function.
- Styled the 'Recent Activity' and 'AI Learning Insights' sections to match the layout, icons, and content of the reference image.
- Verified all changes with a Playwright script to ensure visual consistency.