### PR TITLE
feat: Set Overview as default view

### DIFF
--- a/Kuve-AKU-1/src/App.tsx
+++ b/Kuve-AKU-1/src/App.tsx
@@ -14,7 +14,7 @@ function App() {
   const [showForm, setShowForm] = useState(false);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [isLoginView, setIsLoginView] = useState(true);
-  const [activeView, setActiveView] = useState('claims');
+  const [activeView, setActiveView] = useState('overview');
   const [passwordCriteria, setPasswordCriteria] = useState({
     uppercase: false,
     lowercase: false,

--- a/jules-scratch/verification/verify_dashboard.py
+++ b/jules-scratch/verification/verify_dashboard.py
@@ -9,7 +9,7 @@ def run(playwright):
     # Give the server a moment to start
     time.sleep(10)
 
-    page.goto("http://localhost:5173/")
+    page.goto("http://localhost:5176/")
 
     # Wait for the splash screen to be visible
     page.wait_for_selector('.splash-card', state='visible')
@@ -28,7 +28,7 @@ def run(playwright):
     page.click('button[type="submit"]')
 
     # Wait for the dashboard to load
-    page.wait_for_selector('.dashboard-grid', state='visible')
+    page.wait_for_selector('.dashboard-view', state='visible')
 
     # Take a screenshot of the dashboard
     page.screenshot(path="jules-scratch/verification/verification.png", full_page=True)

--- a/npm_output.log
+++ b/npm_output.log
@@ -1,4 +1,8 @@
+Port 5173 is in use, trying another one...
+Port 5174 is in use, trying another one...
+Port 5175 is in use, trying another one...
 
-> vite-react-app@0.0.0 dev
-> vite
+  VITE v5.4.20  ready in 283 ms
 
+  ➜  Local:   http://localhost:5176/
+  ➜  Network: use --host to expose


### PR DESCRIPTION
This commit updates the application to make the "Overview" section the default page after a successful login.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The application now opens to the Overview view by default instead of Claims.

* **Tests**
  * Updated end-to-end verification to use the new app address and detect the revised dashboard container after login.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->