### PR TITLE
fix: Correct sidebar logo path and styling

### DIFF
--- a/Kuve-AKU-1/src/components/Sidebar.tsx
+++ b/Kuve-AKU-1/src/components/Sidebar.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import './Sidebar.css';
-import akuveraLogo from '../assets/akuvera-logo.png';
 
 interface SidebarProps {
   activeView: string;
@@ -11,7 +10,7 @@ const Sidebar: React.FC<SidebarProps> = ({ activeView, setActiveView }) => {
   return (
     <aside className="sidebar">
       <div className="sidebar-header">
-        <img src={akuveraLogo} alt="Akuvera Logo" className="sidebar-logo" />
+        <img src="/akuvera-logo.png" alt="Akuvera Logo" className="sidebar-logo" />
       </div>
       <nav className="sidebar-nav">
         <ul>


### PR DESCRIPTION
This commit fixes an issue where the Akuvera logo was not displaying in the sidebar. The `Sidebar.tsx` component has been updated to use the correct image path (`/akuvera-logo.png`) and the import statement has been removed.

This change ensures the logo is displayed correctly as per the user's request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the sidebar logo to use a static image path instead of an imported asset. This simplifies asset handling and aligns logo loading across environments. No functional or visual changes are expected in the sidebar or navigation. In rare cases, a hard refresh may be needed to load the logo from the new path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->