### PR TITLE
feat: Replace sidebar header with logo

### DIFF
--- a/Kuve-AKU-1/src/components/Sidebar.css
+++ b/Kuve-AKU-1/src/components/Sidebar.css
@@ -18,11 +18,15 @@
 .sidebar-header {
   padding: 0 24px;
   margin-bottom: 24px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .sidebar-logo {
   height: 40px;
-  margin-bottom: 8px;
+  display: block;
+  margin: 0 auto;
 }
 
 .sidebar-tagline {

--- a/Kuve-AKU-1/src/components/Sidebar.tsx
+++ b/Kuve-AKU-1/src/components/Sidebar.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import './Sidebar.css';
-import akuveraLogo from '../assets/akuvera-logo.png';
 
 interface SidebarProps {
   activeView: string;
@@ -11,8 +10,7 @@ const Sidebar: React.FC<SidebarProps> = ({ activeView, setActiveView }) => {
   return (
     <aside className="sidebar">
       <div className="sidebar-header">
-        <img src={akuveraLogo} alt="Akuvera Logo" className="sidebar-logo" />
-        <p className="sidebar-tagline">Delivers clarity and truth in denial logic</p>
+        <img src="/akuvera-logo.png" alt="Akuvera Logo" className="sidebar-logo" />
       </div>
       <nav className="sidebar-nav">
         <ul>


### PR DESCRIPTION
Replaces the sidebar header with the Akuvera logo, centered and without the tagline. The logo is now referenced from the public directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Centered the sidebar header and logo for a cleaner, more balanced look.
  - Simplified the header by removing the tagline, showcasing only the logo.

- **Refactor**
  - Updated how the logo asset is referenced to improve reliability and consistency in rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->