### PR TITLE
fix: Set checkbox background to white in review issues modal

### DIFF
--- a/Kuve-AKU-1/src/components/ReviewIssues.css
+++ b/Kuve-AKU-1/src/components/ReviewIssues.css
@@ -74,6 +74,10 @@
   gap: 12px;
 }
 
+.cell.patient input[type="checkbox"] {
+  background-color: white;
+}
+
 .patient-name {
   font-weight: 500;
 }


### PR DESCRIPTION
- Updated the CSS for the `ReviewIssues` component to set the background color of the checkboxes to white.
- Note: Frontend verification was skipped due to a persistent environment issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Applied a new CSS rule so checkboxes within patient cells render with a white background.
  * The update targets only the checkbox visuals inside patient-specific table cells.
  * Affects styling only; no interaction, layout, or component behavior changes.
  * No other views or elements were modified as part of this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->