### PR TITLE
refactor: Remove labels from denial types distribution chart

### DIFF
--- a/Kuve-AKU-1/src/components/DashboardOverview.tsx
+++ b/Kuve-AKU-1/src/components/DashboardOverview.tsx
@@ -33,31 +33,6 @@ const CustomTooltip = ({ active, payload }: any) => {
     return null;
 };
 
-const renderCustomizedLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, percent, name, color }) => {
-  const RADIAN = Math.PI / 180;
-  const radius = innerRadius + (outerRadius - innerRadius) * 0.5;
-  const labelRadius = outerRadius + 20;
-  const x = cx + labelRadius * Math.cos(-midAngle * RADIAN);
-  const y = cy + labelRadius * Math.sin(-midAngle * RADIAN);
-  const sin = Math.sin(-RADIAN * midAngle);
-  const cos = Math.cos(-RADIAN * midAngle);
-  const sx = cx + (outerRadius + 5) * cos;
-  const sy = cy + (outerRadius + 5) * sin;
-  const mx = cx + (outerRadius + 15) * cos;
-  const my = cy + (outerRadius + 15) * sin;
-  const ex = mx + (cos >= 0 ? 1 : -1) * 12;
-  const ey = my;
-  const textAnchor = cos >= 0 ? 'start' : 'end';
-
-  return (
-    <g>
-      <path d={`M${sx},${sy}L${mx},${my}L${ex},${ey}`} stroke={color} fill="none" />
-      <circle cx={sx} cy={sy} r={2} fill={color} stroke="none" />
-      <text x={ex + (cos >= 0 ? 1 : -1) * 12} y={ey} textAnchor={textAnchor} fill="#333" dy={-6} style={{ fontSize: '12px', fontWeight: '500' }}>{name}</text>
-      <text x={ex + (cos >= 0 ? 1 : -1) * 12} y={ey} textAnchor={textAnchor} fill="#6B7280" dy={8} style={{ fontSize: '11px' }}>{`${(percent * 100).toFixed(0)}%`}</text>
-    </g>
-  );
-};
 
 const AlertIcon = () => (
   <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
@@ -199,7 +174,6 @@ const DashboardOverview = () => {
                                 cx="50%"
                                 cy="50%"
                                 labelLine={false}
-                                label={renderCustomizedLabel}
                                 outerRadius={100}
                                 innerRadius={70}
                                 dataKey="value"


### PR DESCRIPTION
This commit removes the external labels from the 'Denial Types Distribution' pie chart on the Dashboard Overview page, as requested.

The changes include:
- Removing the `label` prop from the `Pie` component in `DashboardOverview.tsx`.
- Deleting the `renderCustomizedLabel` function, which is no longer needed.

This simplifies the chart's appearance and focuses on the visual representation of the data within the pie chart itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the Denial Types Distribution pie chart by removing custom label rendering; it now uses default labels.
  * No changes to data or interactions; segments and tooltips behave as before.

* **Style**
  * Streamlined chart appearance to reduce visual clutter and improve consistency with other charts.
  * Enhances readability of labels, especially at smaller sizes or dense datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->