### PR TITLE
feat: Add actions menu to claims table

### DIFF
--- a/Kuve-AKU-1/src/components/ActionsMenu.css
+++ b/Kuve-AKU-1/src/components/ActionsMenu.css
@@ -1,0 +1,36 @@
+.actions-menu-container {
+  position: absolute;
+  top: calc(100% + 5px);
+  right: 0;
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: max-content;
+  z-index: 1001;
+}
+
+.action-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  color: #333;
+  transition: background-color 0.2s;
+}
+
+.action-item:hover {
+  background-color: #f5f5f5;
+}
+
+.action-item .action-icon {
+  width: 20px;
+  height: 20px;
+  color: #555;
+}

--- a/Kuve-AKU-1/src/components/ActionsMenu.tsx
+++ b/Kuve-AKU-1/src/components/ActionsMenu.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useRef } from 'react';
+import './ActionsMenu.css';
+
+interface ActionsMenuProps {
+  onClose: () => void;
+}
+
+const ActionsMenu: React.FC<ActionsMenuProps> = ({ onClose }) => {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [onClose]);
+
+  return (
+    <div className="actions-menu-container" ref={menuRef}>
+      <div className="action-item">
+        {/* Eye Icon */}
+        <svg xmlns="http://www.w3.org/2000/svg" className="action-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+        </svg>
+        <span>View Details</span>
+      </div>
+      <div className="action-item">
+        {/* AI Bot Icon */}
+        <svg xmlns="http://www.w3.org/2000/svg" className="action-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M17.657 18.657A8 8 0 016.343 7.343S7 9 9 10h6c2-1 2.343-2.657 2.343-2.657m0 0A8 8 0 0118.657 17.657m-1.314-1.314A8.002 8.002 0 016.343 6.343" />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M12 2v2m0 16v2M4.929 4.929l1.414 1.414m11.314 11.314l1.414 1.414M2 12h2m16 0h2M4.929 19.071l1.414-1.414m11.314-11.314l1.414-1.414" />
+        </svg>
+        <span>Run AI Bot</span>
+      </div>
+      <div className="action-item">
+        {/* Contact Provider Icon */}
+        <svg xmlns="http://www.w3.org/2000/svg" className="action-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+        </svg>
+        <span>Contact Provider</span>
+      </div>
+    </div>
+  );
+};
+
+export default ActionsMenu;

--- a/Kuve-AKU-1/src/components/ClaimsManagement.css
+++ b/Kuve-AKU-1/src/components/ClaimsManagement.css
@@ -391,7 +391,15 @@
 
 .actions-cell {
   text-align: center;
+  position: relative;
 }
+
+.actions-container {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
 .actions-icon {
   width: 16px;
   height: 16px;
@@ -407,6 +415,8 @@
   padding: 4px 8px;
   cursor: pointer;
 }
+
+/* This class is no longer used */
 
 /* --- Responsive Styles --- */
 

--- a/Kuve-AKU-1/src/components/ClaimsManagement.tsx
+++ b/Kuve-AKU-1/src/components/ClaimsManagement.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import './ClaimsManagement.css';
+import ActionsMenu from './ActionsMenu';
 
 // ... (interface definitions if needed)
 
@@ -98,6 +99,7 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
   const [activeTab, setActiveTab] = useState('All Claims');
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedClaims, setSelectedClaims] = useState<string[]>([]);
+  const [openMenuId, setOpenMenuId] = useState<string | null>(null);
 
   const handleTabClick = (tab: string) => {
     setActiveTab(tab);
@@ -129,6 +131,14 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
   };
 
   const areAllSelected = filteredClaims.length > 0 && selectedClaims.length === filteredClaims.length;
+
+  const handleActionsClick = (claimId: string) => {
+    setOpenMenuId(prev => (prev === claimId ? null : claimId));
+  };
+
+  const handleCloseMenu = () => {
+    setOpenMenuId(null);
+  };
 
   const exportToCsv = () => {
     const headers = ['Claim ID', 'Customer', 'Provider', 'Payer', 'Date Issued', 'Amount', 'Status'];
@@ -305,11 +315,25 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
                   </div>
                 </td>
                 <td className="actions-cell">
-                  {claim.status === 'Needs Review' ? (
-                    <button className="review-button" onClick={() => onOpenReviewModal(claim)}>Review</button>
-                  ) : (
-                    <svg className="actions-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" /></svg>
-                  )}
+                  <div className="actions-container">
+                    {claim.status === 'Needs Review' ? (
+                      <button className="review-button" onClick={() => onOpenReviewModal(claim)}>Review</button>
+                    ) : (
+                      <svg
+                        className="actions-icon"
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        onClick={() => handleActionsClick(claim.claimId)}
+                      >
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" />
+                      </svg>
+                    )}
+                    {openMenuId === claim.claimId && (
+                      <ActionsMenu onClose={handleCloseMenu} />
+                    )}
+                  </div>
                 </td>
               </tr>
             ))}


### PR DESCRIPTION
- Creates a new `ActionsMenu` component to display a pop-up menu with "View Details", "Run AI Bot", and "Contact Provider" options.
- Integrates the `ActionsMenu` into the `ClaimsManagement` component, making it appear when the actions icon is clicked.
- Implements state management to control the visibility of the menu and a mechanism to close it when clicking outside.
- Adds CSS for styling the menu to match the provided design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a per-claim actions menu in Claims Management for non-Needs Review items, offering View Details, Run AI Bot, and Contact Provider. Menu toggles via an icon and closes on outside click.
* **Style**
  * Introduced new styles for the actions menu, including layout, spacing, hover states, and icon sizing. Adjusted actions cell/container positioning for better alignment.
* **Documentation**
  * Noted that a specific CSS class is no longer used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->