### PR TITLE
feat: Make actions icon conditional and replace review button

### DIFF
--- a/Kuve-AKU-1/src/components/ActionsMenu.tsx
+++ b/Kuve-AKU-1/src/components/ActionsMenu.tsx
@@ -23,7 +23,7 @@ const ActionsMenu: React.FC<ActionsMenuProps> = ({ onClose }) => {
 
   return (
     <div className="actions-menu-container" ref={menuRef}>
-      <div className="action-item">
+      <div className="action-item" onClick={() => console.log('View Details clicked')}>
         {/* Eye Icon */}
         <svg xmlns="http://www.w3.org/2000/svg" className="action-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
           <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
@@ -31,7 +31,7 @@ const ActionsMenu: React.FC<ActionsMenuProps> = ({ onClose }) => {
         </svg>
         <span>View Details</span>
       </div>
-      <div className="action-item">
+      <div className="action-item" onClick={() => console.log('Run AI Bot clicked')}>
         {/* AI Bot Icon */}
         <svg xmlns="http://www.w3.org/2000/svg" className="action-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
           <path strokeLinecap="round" strokeLinejoin="round" d="M17.657 18.657A8 8 0 016.343 7.343S7 9 9 10h6c2-1 2.343-2.657 2.343-2.657m0 0A8 8 0 0118.657 17.657m-1.314-1.314A8.002 8.002 0 016.343 6.343" />
@@ -39,7 +39,7 @@ const ActionsMenu: React.FC<ActionsMenuProps> = ({ onClose }) => {
         </svg>
         <span>Run AI Bot</span>
       </div>
-      <div className="action-item">
+      <div className="action-item" onClick={() => console.log('Contact Provider clicked')}>
         {/* Contact Provider Icon */}
         <svg xmlns="http://www.w3.org/2000/svg" className="action-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
           <path strokeLinecap="round" strokeLinejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />

--- a/Kuve-AKU-1/src/components/ClaimsManagement.css
+++ b/Kuve-AKU-1/src/components/ClaimsManagement.css
@@ -407,14 +407,7 @@
   cursor: pointer;
 }
 
-.review-button {
-  background-color: #2563EB;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 8px;
-  cursor: pointer;
-}
+/* .review-button is no longer used */
 
 /* This class is no longer used */
 

--- a/Kuve-AKU-1/src/components/ClaimsManagement.tsx
+++ b/Kuve-AKU-1/src/components/ClaimsManagement.tsx
@@ -316,21 +316,23 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
                 </td>
                 <td className="actions-cell">
                   <div className="actions-container">
-                    {claim.status === 'Needs Review' ? (
-                      <button className="review-button" onClick={() => onOpenReviewModal(claim)}>Review</button>
-                    ) : (
-                      <svg
-                        className="actions-icon"
-                        xmlns="http://www.w3.org/2000/svg"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        onClick={() => handleActionsClick(claim.claimId)}
-                      >
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" />
-                      </svg>
-                    )}
-                    {openMenuId === claim.claimId && (
+                    <svg
+                      className="actions-icon"
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      onClick={() => {
+                        if (claim.status === 'Needs Review') {
+                          onOpenReviewModal(claim);
+                        } else {
+                          handleActionsClick(claim.claimId);
+                        }
+                      }}
+                    >
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" />
+                    </svg>
+                    {openMenuId === claim.claimId && claim.status !== 'Needs Review' && (
                       <ActionsMenu onClose={handleCloseMenu} />
                     )}
                   </div>


### PR DESCRIPTION
- Replaces the 'Review' button with the standard three-dots action icon for all claims to maintain a consistent UI.
- The click handler for the actions icon is now conditional. If the claim status is 'Needs Review', it triggers the review modal. Otherwise, it opens the actions pop-up menu.
- Adds placeholder onClick handlers to the items in the ActionsMenu to make them interactive.