### PR TITLE
feat: Unify actions menu functionality for all claims

### DIFF
--- a/Kuve-AKU-1/src/components/ActionsMenu.tsx
+++ b/Kuve-AKU-1/src/components/ActionsMenu.tsx
@@ -3,9 +3,11 @@ import './ActionsMenu.css';
 
 interface ActionsMenuProps {
   onClose: () => void;
+  claimStatus: string;
+  onReviewClick: () => void;
 }
 
-const ActionsMenu: React.FC<ActionsMenuProps> = ({ onClose }) => {
+const ActionsMenu: React.FC<ActionsMenuProps> = ({ onClose, claimStatus, onReviewClick }) => {
   const menuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -23,29 +25,41 @@ const ActionsMenu: React.FC<ActionsMenuProps> = ({ onClose }) => {
 
   return (
     <div className="actions-menu-container" ref={menuRef}>
-      <div className="action-item" onClick={() => console.log('View Details clicked')}>
-        {/* Eye Icon */}
-        <svg xmlns="http://www.w3.org/2000/svg" className="action-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-          <path strokeLinecap="round" strokeLinejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-        </svg>
-        <span>View Details</span>
-      </div>
-      <div className="action-item" onClick={() => console.log('Run AI Bot clicked')}>
-        {/* AI Bot Icon */}
-        <svg xmlns="http://www.w3.org/2000/svg" className="action-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M17.657 18.657A8 8 0 016.343 7.343S7 9 9 10h6c2-1 2.343-2.657 2.343-2.657m0 0A8 8 0 0118.657 17.657m-1.314-1.314A8.002 8.002 0 016.343 6.343" />
-          <path strokeLinecap="round" strokeLinejoin="round" d="M12 2v2m0 16v2M4.929 4.929l1.414 1.414m11.314 11.314l1.414 1.414M2 12h2m16 0h2M4.929 19.071l1.414-1.414m11.314-11.314l1.414-1.414" />
-        </svg>
-        <span>Run AI Bot</span>
-      </div>
-      <div className="action-item" onClick={() => console.log('Contact Provider clicked')}>
-        {/* Contact Provider Icon */}
-        <svg xmlns="http://www.w3.org/2000/svg" className="action-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-        </svg>
-        <span>Contact Provider</span>
-      </div>
+      {claimStatus === 'Needs Review' ? (
+        <div className="action-item" onClick={onReviewClick}>
+          {/* Review Icon */}
+          <svg xmlns="http://www.w3.org/2000/svg" className="action-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.536L16.732 3.732z" />
+          </svg>
+          <span>Review Claim</span>
+        </div>
+      ) : (
+        <>
+          <div className="action-item" onClick={() => console.log('View Details clicked')}>
+            {/* Eye Icon */}
+            <svg xmlns="http://www.w3.org/2000/svg" className="action-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              <path strokeLinecap="round" strokeLinejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+            </svg>
+            <span>View Details</span>
+          </div>
+          <div className="action-item" onClick={() => console.log('Run AI Bot clicked')}>
+            {/* AI Bot Icon */}
+            <svg xmlns="http://www.w3.org/2000/svg" className="action-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M17.657 18.657A8 8 0 016.343 7.343S7 9 9 10h6c2-1 2.343-2.657 2.343-2.657m0 0A8 8 0 0118.657 17.657m-1.314-1.314A8.002 8.002 0 016.343 6.343" />
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 2v2m0 16v2M4.929 4.929l1.414 1.414m11.314 11.314l1.414 1.414M2 12h2m16 0h2M4.929 19.071l1.414-1.414m11.314-11.314l1.414-1.414" />
+            </svg>
+            <span>Run AI Bot</span>
+          </div>
+          <div className="action-item" onClick={() => console.log('Contact Provider clicked')}>
+            {/* Contact Provider Icon */}
+            <svg xmlns="http://www.w3.org/2000/svg" className="action-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+            </svg>
+            <span>Contact Provider</span>
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/Kuve-AKU-1/src/components/ClaimsManagement.tsx
+++ b/Kuve-AKU-1/src/components/ClaimsManagement.tsx
@@ -322,18 +322,16 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
                       fill="none"
                       viewBox="0 0 24 24"
                       stroke="currentColor"
-                      onClick={() => {
-                        if (claim.status === 'Needs Review') {
-                          onOpenReviewModal(claim);
-                        } else {
-                          handleActionsClick(claim.claimId);
-                        }
-                      }}
+                      onClick={() => handleActionsClick(claim.claimId)}
                     >
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" />
                     </svg>
-                    {openMenuId === claim.claimId && claim.status !== 'Needs Review' && (
-                      <ActionsMenu onClose={handleCloseMenu} />
+                    {openMenuId === claim.claimId && (
+                      <ActionsMenu
+                        onClose={handleCloseMenu}
+                        claimStatus={claim.status}
+                        onReviewClick={() => onOpenReviewModal(claim)}
+                      />
                     )}
                   </div>
                 </td>


### PR DESCRIPTION
- The actions icon now opens a pop-up menu for all claims, including those with a 'Needs Review' status, to provide a consistent user experience.
- The `ActionsMenu` component is now conditional. For claims needing review, it displays a 'Review Claim' option that triggers the review modal.
- For all other claim statuses, the menu displays the standard actions: 'View Details', 'Run AI Bot', and 'Contact Provider'.