### PR TITLE
feat: Standardize actions menu for all claims

### DIFF
--- a/Kuve-AKU-1/src/components/ActionsMenu.tsx
+++ b/Kuve-AKU-1/src/components/ActionsMenu.tsx
@@ -3,11 +3,9 @@ import './ActionsMenu.css';
 
 interface ActionsMenuProps {
   onClose: () => void;
-  claimStatus: string;
-  onReviewClick: () => void;
 }
 
-const ActionsMenu: React.FC<ActionsMenuProps> = ({ onClose, claimStatus, onReviewClick }) => {
+const ActionsMenu: React.FC<ActionsMenuProps> = ({ onClose }) => {
   const menuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -25,41 +23,29 @@ const ActionsMenu: React.FC<ActionsMenuProps> = ({ onClose, claimStatus, onRevie
 
   return (
     <div className="actions-menu-container" ref={menuRef}>
-      {claimStatus === 'Needs Review' ? (
-        <div className="action-item" onClick={onReviewClick}>
-          {/* Review Icon */}
-          <svg xmlns="http://www.w3.org/2000/svg" className="action-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.536L16.732 3.732z" />
-          </svg>
-          <span>Review Claim</span>
-        </div>
-      ) : (
-        <>
-          <div className="action-item" onClick={() => console.log('View Details clicked')}>
-            {/* Eye Icon */}
-            <svg xmlns="http://www.w3.org/2000/svg" className="action-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-              <path strokeLinecap="round" strokeLinejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-            </svg>
-            <span>View Details</span>
-          </div>
-          <div className="action-item" onClick={() => console.log('Run AI Bot clicked')}>
-            {/* AI Bot Icon */}
-            <svg xmlns="http://www.w3.org/2000/svg" className="action-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M17.657 18.657A8 8 0 016.343 7.343S7 9 9 10h6c2-1 2.343-2.657 2.343-2.657m0 0A8 8 0 0118.657 17.657m-1.314-1.314A8.002 8.002 0 016.343 6.343" />
-              <path strokeLinecap="round" strokeLinejoin="round" d="M12 2v2m0 16v2M4.929 4.929l1.414 1.414m11.314 11.314l1.414 1.414M2 12h2m16 0h2M4.929 19.071l1.414-1.414m11.314-11.314l1.414-1.414" />
-            </svg>
-            <span>Run AI Bot</span>
-          </div>
-          <div className="action-item" onClick={() => console.log('Contact Provider clicked')}>
-            {/* Contact Provider Icon */}
-            <svg xmlns="http://www.w3.org/2000/svg" className="action-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-            </svg>
-            <span>Contact Provider</span>
-          </div>
-        </>
-      )}
+      <div className="action-item" onClick={() => console.log('View Details clicked')}>
+        {/* Eye Icon */}
+        <svg xmlns="http://www.w3.org/2000/svg" className="action-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+        </svg>
+        <span>View Details</span>
+      </div>
+      <div className="action-item" onClick={() => console.log('Run AI Bot clicked')}>
+        {/* AI Bot Icon */}
+        <svg xmlns="http://www.w3.org/2000/svg" className="action-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M17.657 18.657A8 8 0 016.343 7.343S7 9 9 10h6c2-1 2.343-2.657 2.343-2.657m0 0A8 8 0 0118.657 17.657m-1.314-1.314A8.002 8.002 0 016.343 6.343" />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M12 2v2m0 16v2M4.929 4.929l1.414 1.414m11.314 11.314l1.414 1.414M2 12h2m16 0h2M4.929 19.071l1.414-1.414m11.314-11.314l1.414-1.414" />
+        </svg>
+        <span>Run AI Bot</span>
+      </div>
+      <div className="action-item" onClick={() => console.log('Contact Provider clicked')}>
+        {/* Contact Provider Icon */}
+        <svg xmlns="http://www.w3.org/2000/svg" className="action-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+        </svg>
+        <span>Contact Provider</span>
+      </div>
     </div>
   );
 };

--- a/Kuve-AKU-1/src/components/ClaimsManagement.css
+++ b/Kuve-AKU-1/src/components/ClaimsManagement.css
@@ -263,48 +263,6 @@
   white-space: nowrap;
 }
 
-.th-checkbox, .td-checkbox {
-  width: 1%;
-  padding-right: 0;
-  text-align: center;
-}
-
-/* Custom Checkbox Styles */
-.th-checkbox input[type="checkbox"],
-.td-checkbox input[type="checkbox"] {
-  appearance: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  background-color: #fff;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  width: 16px;
-  height: 16px;
-  cursor: pointer;
-  position: relative;
-  vertical-align: middle;
-  margin: 0;
-}
-
-.th-checkbox input[type="checkbox"]:checked,
-.td-checkbox input[type="checkbox"]:checked {
-  background-color: #1976D2;
-  border-color: #1976D2;
-}
-
-.th-checkbox input[type="checkbox"]:checked::after,
-.td-checkbox input[type="checkbox"]:checked::after {
-  content: '';
-  position: absolute;
-  left: 5px;
-  top: 1px;
-  width: 4px;
-  height: 8px;
-  border: solid white;
-  border-width: 0 2px 2px 0;
-  transform: rotate(45deg);
-}
-
 .claims-table th {
   font-weight: 500;
   color: #333333;
@@ -390,8 +348,14 @@
 }
 
 .actions-cell {
-  text-align: center;
   position: relative;
+  text-align: center;
+}
+
+.actions-container {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
 }
 
 .actions-container {
@@ -407,9 +371,21 @@
   cursor: pointer;
 }
 
-/* .review-button is no longer used */
+.actions-container .actions-menu-container {
+  position: absolute;
+  top: calc(100% + 5px);
+  right: 0;
+  z-index: 1001;
+}
 
-/* This class is no longer used */
+.review-button {
+  background-color: #2563EB;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 8px;
+  cursor: pointer;
+}
 
 /* --- Responsive Styles --- */
 

--- a/Kuve-AKU-1/src/components/ClaimsManagement.tsx
+++ b/Kuve-AKU-1/src/components/ClaimsManagement.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import './ClaimsManagement.css';
 import ActionsMenu from './ActionsMenu';
 
@@ -98,11 +98,14 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
   const [claimsData, setClaimsData] = useState(initialClaimsData);
   const [activeTab, setActiveTab] = useState('All Claims');
   const [searchQuery, setSearchQuery] = useState('');
-  const [selectedClaims, setSelectedClaims] = useState<string[]>([]);
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
 
-  const handleTabClick = (tab: string) => {
-    setActiveTab(tab);
+  const handleActionsClick = (claimId: string) => {
+    setOpenMenuId(prev => (prev === claimId ? null : claimId));
+  };
+
+  const handleCloseMenu = () => {
+    setOpenMenuId(null);
   };
 
   const filteredClaims = claimsData.filter(claim => {
@@ -113,32 +116,6 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
                         claim.provider.toLowerCase().includes(searchQuery.toLowerCase());
     return statusMatch && searchMatch;
   });
-
-  const handleSelectAll = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.checked) {
-      setSelectedClaims(filteredClaims.map(claim => claim.claimId));
-    } else {
-      setSelectedClaims([]);
-    }
-  };
-
-  const handleSelectClaim = (claimId: string) => {
-    setSelectedClaims(prev =>
-      prev.includes(claimId)
-        ? prev.filter(id => id !== claimId)
-        : [...prev, claimId]
-    );
-  };
-
-  const areAllSelected = filteredClaims.length > 0 && selectedClaims.length === filteredClaims.length;
-
-  const handleActionsClick = (claimId: string) => {
-    setOpenMenuId(prev => (prev === claimId ? null : claimId));
-  };
-
-  const handleCloseMenu = () => {
-    setOpenMenuId(null);
-  };
 
   const exportToCsv = () => {
     const headers = ['Claim ID', 'Customer', 'Provider', 'Payer', 'Date Issued', 'Amount', 'Status'];
@@ -271,13 +248,6 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
         <table className="claims-table">
           <thead>
             <tr>
-              <th className="th-checkbox">
-                <input
-                  type="checkbox"
-                  checked={areAllSelected}
-                  onChange={handleSelectAll}
-                />
-              </th>
               <th className="th-claim-id">Claim ID</th>
               <th className="th-customer">Customer</th>
               <th className="th-provider">Provider</th>
@@ -291,13 +261,6 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
           <tbody>
             {filteredClaims.map((claim, index) => (
               <tr key={index}>
-                <td className="td-checkbox">
-                  <input
-                    type="checkbox"
-                    checked={selectedClaims.includes(claim.claimId)}
-                    onChange={() => handleSelectClaim(claim.claimId)}
-                  />
-                </td>
                 <td className="claim-id">{claim.claimId}</td>
                 <td>{claim.customer}</td>
                 <td><div className="pill-badge">{claim.provider}</div></td>
@@ -327,11 +290,7 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" />
                     </svg>
                     {openMenuId === claim.claimId && (
-                      <ActionsMenu
-                        onClose={handleCloseMenu}
-                        claimStatus={claim.status}
-                        onReviewClick={() => onOpenReviewModal(claim)}
-                      />
+                      <ActionsMenu onClose={handleCloseMenu} />
                     )}
                   </div>
                 </td>


### PR DESCRIPTION
- Ensures that clicking the actions icon on any claim, regardless of status, opens the same pop-up menu.
- Removes the conditional logic that previously showed a different menu or action for 'Needs Review' claims.
- The `ActionsMenu` component is now always rendered with the standard options: 'View Details', 'Run AI Bot', and 'Contact Provider'.