### PR TITLE
fix: Restore checkboxes and correct pop-up styling

### DIFF
--- a/Kuve-AKU-1/src/components/ActionsMenu.css
+++ b/Kuve-AKU-1/src/components/ActionsMenu.css
@@ -1,43 +1,54 @@
 .actions-menu-container {
   position: absolute;
-  top: calc(100% + 5px);
+  top: calc(100% + 8px); /* 8px spacing from the icon */
   right: 0;
-  background-color: white;
-  border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  background-color: #FFFFFF;
+  border-radius: 12px; /* Increased border radius */
+  box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.1); /* Softer shadow */
   padding: 8px;
   display: flex;
   flex-direction: column;
   gap: 4px;
-  width: max-content;
+  width: 200px; /* Fixed width */
   z-index: 1001;
+  border: 1px solid #F0F0F0; /* Subtle border */
 }
 
 .action-item {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 10px 12px;
-  border-radius: 6px;
+  padding: 12px; /* Increased padding */
+  border-radius: 8px; /* Slightly rounded corners for items */
   cursor: pointer;
   font-size: 14px;
-  color: #333;
+  font-weight: 500; /* Medium weight */
+  color: #374151; /* Dark gray text */
+  background-color: transparent;
+  border: none;
+  text-align: left;
+  width: 100%;
   transition: background-color 0.2s;
 }
 
 .action-item:hover {
-  background-color: #f5f5f5;
+  background-color: #F3F4F6; /* Light gray hover */
+}
+
+.action-item:disabled {
+  color: #9CA3AF;
+  cursor: not-allowed;
 }
 
 .action-item .action-icon {
   width: 20px;
   height: 20px;
-  color: #555;
+  color: #6B7280; /* Medium gray icon */
 }
 
 .loader {
-  border: 2px solid #f3f3f3;
-  border-top: 2px solid #3498db;
+  border: 2px solid #E5E7EB;
+  border-top: 2px solid #4F46E5; /* Indigo spinner */
   border-radius: 50%;
   width: 16px;
   height: 16px;

--- a/Kuve-AKU-1/src/components/ClaimsManagement.css
+++ b/Kuve-AKU-1/src/components/ClaimsManagement.css
@@ -358,10 +358,46 @@
   align-items: center;
 }
 
-.actions-container {
+.th-checkbox, .td-checkbox {
+  width: 1%;
+  padding-right: 0;
+  text-align: center;
+}
+
+/* Custom Checkbox Styles */
+.th-checkbox input[type="checkbox"],
+.td-checkbox input[type="checkbox"] {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
   position: relative;
-  display: inline-flex;
-  align-items: center;
+  vertical-align: middle;
+  margin: 0;
+}
+
+.th-checkbox input[type="checkbox"]:checked,
+.td-checkbox input[type="checkbox"]:checked {
+  background-color: #1976D2;
+  border-color: #1976D2;
+}
+
+.th-checkbox input[type="checkbox"]:checked::after,
+.td-checkbox input[type="checkbox"]:checked::after {
+  content: '';
+  position: absolute;
+  left: 5px;
+  top: 1px;
+  width: 4px;
+  height: 8px;
+  border: solid white;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
 }
 
 .actions-icon {

--- a/Kuve-AKU-1/src/components/ClaimsManagement.tsx
+++ b/Kuve-AKU-1/src/components/ClaimsManagement.tsx
@@ -98,6 +98,7 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
   const [claimsData, setClaimsData] = useState(initialClaimsData);
   const [activeTab, setActiveTab] = useState('All Claims');
   const [searchQuery, setSearchQuery] = useState('');
+  const [selectedClaims, setSelectedClaims] = useState<string[]>([]);
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
 
   const handleActionsClick = (claimId: string) => {
@@ -108,6 +109,26 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
     setOpenMenuId(null);
   };
 
+  const handleSelectAll = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.checked) {
+      setSelectedClaims(filteredClaims.map(claim => claim.claimId));
+    } else {
+      setSelectedClaims([]);
+    }
+  };
+
+  const handleSelectClaim = (claimId: string) => {
+    setSelectedClaims(prev =>
+      prev.includes(claimId)
+        ? prev.filter(id => id !== claimId)
+        : [...prev, claimId]
+    );
+  };
+
+  const handleTabClick = (tab: string) => {
+    setActiveTab(tab);
+  };
+
   const filteredClaims = claimsData.filter(claim => {
     const statusMatch = activeTab === 'All Claims' ||
                         (activeTab === 'Sent' ? claim.status === 'Approved & Sent' : claim.status === activeTab);
@@ -116,6 +137,8 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
                         claim.provider.toLowerCase().includes(searchQuery.toLowerCase());
     return statusMatch && searchMatch;
   });
+
+  const areAllSelected = filteredClaims.length > 0 && selectedClaims.length === filteredClaims.length;
 
   const exportToCsv = () => {
     const headers = ['Claim ID', 'Customer', 'Provider', 'Payer', 'Date Issued', 'Amount', 'Status'];
@@ -248,6 +271,13 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
         <table className="claims-table">
           <thead>
             <tr>
+              <th className="th-checkbox">
+                <input
+                  type="checkbox"
+                  checked={areAllSelected}
+                  onChange={handleSelectAll}
+                />
+              </th>
               <th className="th-claim-id">Claim ID</th>
               <th className="th-customer">Customer</th>
               <th className="th-provider">Provider</th>
@@ -261,6 +291,13 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
           <tbody>
             {filteredClaims.map((claim, index) => (
               <tr key={index}>
+                <td className="td-checkbox">
+                  <input
+                    type="checkbox"
+                    checked={selectedClaims.includes(claim.claimId)}
+                    onChange={() => handleSelectClaim(claim.claimId)}
+                  />
+                </td>
                 <td className="claim-id">{claim.claimId}</td>
                 <td>{claim.customer}</td>
                 <td><div className="pill-badge">{claim.provider}</div></td>


### PR DESCRIPTION
- Restores the checkbox functionality in the claims table, including the 'select all' checkbox and individual row checkboxes.
- Corrects the styling of the actions pop-up menu to be a pixel-perfect match of the user's provided image.