### PR TITLE
feat: Add loading modal for 'Run AI Bot' action

### DIFF
--- a/Kuve-AKU-1/src/components/ActionsMenu.css
+++ b/Kuve-AKU-1/src/components/ActionsMenu.css
@@ -43,5 +43,19 @@
 .action-item .action-icon {
   width: 20px;
   height: 20px;
-  color: #555;
+  color: #6B7280; /* Medium gray icon */
+}
+
+.loader {
+  border: 2px solid #E5E7EB;
+  border-top: 2px solid #4F46E5; /* Indigo spinner */
+  border-radius: 50%;
+  width: 16px;
+  height: 16px;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
 }

--- a/Kuve-AKU-1/src/components/ActionsMenu.tsx
+++ b/Kuve-AKU-1/src/components/ActionsMenu.tsx
@@ -3,9 +3,10 @@ import './ActionsMenu.css';
 
 interface ActionsMenuProps {
   onClose: () => void;
+  onRunAiBot: () => void;
 }
 
-const ActionsMenu: React.FC<ActionsMenuProps> = ({ onClose }) => {
+const ActionsMenu: React.FC<ActionsMenuProps> = ({ onClose, onRunAiBot }) => {
   const menuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -31,14 +32,14 @@ const ActionsMenu: React.FC<ActionsMenuProps> = ({ onClose }) => {
         </svg>
         <span>View Details</span>
       </div>
-      <div className="action-item" onClick={() => console.log('Run AI Bot clicked')}>
+      <button className="action-item" onClick={onRunAiBot}>
         {/* AI Bot Icon */}
         <svg xmlns="http://www.w3.org/2000/svg" className="action-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
           <path strokeLinecap="round" strokeLinejoin="round" d="M17.657 18.657A8 8 0 016.343 7.343S7 9 9 10h6c2-1 2.343-2.657 2.343-2.657m0 0A8 8 0 0118.657 17.657m-1.314-1.314A8.002 8.002 0 016.343 6.343" />
           <path strokeLinecap="round" strokeLinejoin="round" d="M12 2v2m0 16v2M4.929 4.929l1.414 1.414m11.314 11.314l1.414 1.414M2 12h2m16 0h2M4.929 19.071l1.414-1.414m11.314-11.314l1.414-1.414" />
         </svg>
         <span>Run AI Bot</span>
-      </div>
+      </button>
       <div className="action-item" onClick={() => console.log('Contact Provider clicked')}>
         {/* Contact Provider Icon */}
         <svg xmlns="http://www.w3.org/2000/svg" className="action-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>

--- a/Kuve-AKU-1/src/components/AiBotModal.css
+++ b/Kuve-AKU-1/src/components/AiBotModal.css
@@ -1,0 +1,55 @@
+.ai-bot-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 2000;
+}
+
+.ai-bot-modal-container {
+  background-color: white;
+  border-radius: 16px;
+  padding: 48px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  width: 360px;
+}
+
+.ai-bot-modal-spinner {
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #3498db;
+  border-radius: 50%;
+  width: 48px;
+  height: 48px;
+  animation: spin 1.5s linear infinite;
+}
+
+.ai-bot-modal-title {
+  font-size: 20px;
+  font-weight: 600;
+  color: #111827;
+  margin: 0;
+}
+
+.ai-bot-modal-subtitle {
+  font-size: 14px;
+  color: #6B7280;
+  margin: 0;
+}
+
+.ai-bot-modal-claim-id {
+  font-weight: 600;
+  color: #374151;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}

--- a/Kuve-AKU-1/src/components/AiBotModal.tsx
+++ b/Kuve-AKU-1/src/components/AiBotModal.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import './AiBotModal.css';
+
+interface AiBotModalProps {
+  claimId: string;
+}
+
+const AiBotModal: React.FC<AiBotModalProps> = ({ claimId }) => {
+  return (
+    <div className="ai-bot-modal-overlay">
+      <div className="ai-bot-modal-container">
+        <div className="ai-bot-modal-spinner"></div>
+        <h2 className="ai-bot-modal-title">Running AI Bot</h2>
+        <p className="ai-bot-modal-subtitle">
+          Processing claim <span className="ai-bot-modal-claim-id">{claimId}</span>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default AiBotModal;

--- a/Kuve-AKU-1/src/components/ClaimsManagement.tsx
+++ b/Kuve-AKU-1/src/components/ClaimsManagement.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import './ClaimsManagement.css';
 import ActionsMenu from './ActionsMenu';
+import AiBotModal from './AiBotModal';
 
 // ... (interface definitions if needed)
 
@@ -100,6 +101,8 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedClaims, setSelectedClaims] = useState<string[]>([]);
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
+  const [isAiBotModalOpen, setIsAiBotModalOpen] = useState(false);
+  const [processingClaimId, setProcessingClaimId] = useState<string | null>(null);
 
   const handleActionsClick = (claimId: string) => {
     setOpenMenuId(prev => (prev === claimId ? null : claimId));
@@ -107,6 +110,17 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
 
   const handleCloseMenu = () => {
     setOpenMenuId(null);
+  };
+
+  const handleRunAiBot = (claimId: string) => {
+    setProcessingClaimId(claimId);
+    setIsAiBotModalOpen(true);
+    setOpenMenuId(null); // Close the actions menu
+
+    setTimeout(() => {
+      setIsAiBotModalOpen(false);
+      setProcessingClaimId(null);
+    }, 3000); // Simulate a 3-second process
   };
 
   const handleSelectAll = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -163,6 +177,7 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
   };
 
   return (
+    <>
     <div className="claims-management-page">
       {/* Stat Cards remain the same for now */}
       <div className="claims-stat-cards">
@@ -327,7 +342,7 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" />
                     </svg>
                     {openMenuId === claim.claimId && (
-                      <ActionsMenu onClose={handleCloseMenu} />
+                      <ActionsMenu onClose={handleCloseMenu} onRunAiBot={() => handleRunAiBot(claim.claimId)} />
                     )}
                   </div>
                 </td>
@@ -337,7 +352,11 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
         </table>
       </div>
       </div>
+      {isAiBotModalOpen && processingClaimId && (
+        <AiBotModal claimId={processingClaimId} />
+      )}
     </div>
+    </>
   );
 };
 


### PR DESCRIPTION
- Creates a new `AiBotModal` component to display a loading state when the 'Run AI Bot' action is initiated.
- The modal is displayed with a loading spinner and text indicating that the bot is processing a specific claim.
- The `ClaimsManagement` component now manages the visibility of the modal.
- The `ActionsMenu` component has been refactored to trigger the modal's appearance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an AI Bot action in claim menus that starts a short processing workflow.
  * Introduced a modal showing a spinner and the current claim ID while the AI Bot runs, auto-closing after a few seconds.

* **Style**
  * Updated action icon color for improved visual clarity.
  * Added spinner/loader styles and animations for the new modal experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->