### PR TITLE
feat: Replace AI Bot modal with inline component

### DIFF
--- a/Kuve-AKU-1/src/components/AiBotModal.css
+++ b/Kuve-AKU-1/src/components/AiBotModal.css
@@ -1,55 +1,53 @@
-.ai-bot-modal-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: rgba(0, 0, 0, 0.5);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 2000;
-}
-
 .ai-bot-modal-container {
-  background-color: white;
-  border-radius: 16px;
-  padding: 48px;
+  background-color: #ffffff;
+  border-radius: 8px;
+  padding: 16px;
+  width: 100%;
+  max-width: 950px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  margin-bottom: 24px;
+}
+
+.ai-bot-modal-header {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 16px;
-  width: 360px;
+  margin-bottom: 12px;
 }
 
-.ai-bot-modal-spinner {
-  border: 4px solid #f3f3f3;
-  border-top: 4px solid #3498db;
-  border-radius: 50%;
-  width: 48px;
-  height: 48px;
-  animation: spin 1.5s linear infinite;
-}
-
-.ai-bot-modal-title {
-  font-size: 20px;
-  font-weight: 600;
-  color: #111827;
-  margin: 0;
-}
-
-.ai-bot-modal-subtitle {
-  font-size: 14px;
+.ai-bot-modal-icon {
+  margin-right: 12px;
   color: #6B7280;
-  margin: 0;
 }
 
 .ai-bot-modal-claim-id {
   font-weight: 600;
-  color: #374151;
+  color: #111827;
+  font-size: 16px;
 }
 
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+.ai-bot-modal-percentage {
+  margin-left: auto;
+  font-weight: 600;
+  color: #111827;
+  font-size: 16px;
+}
+
+.ai-bot-modal-progress-bar {
+  width: 100%;
+  background-color: #e5e7eb;
+  border-radius: 4px;
+  height: 8px;
+  margin-bottom: 12px;
+}
+
+.ai-bot-modal-progress {
+  background-color: #1976D2;
+  height: 100%;
+  border-radius: 4px;
+}
+
+.ai-bot-modal-description {
+  color: #6B7280;
+  font-size: 14px;
+  margin: 0;
 }

--- a/Kuve-AKU-1/src/components/AiBotModal.tsx
+++ b/Kuve-AKU-1/src/components/AiBotModal.tsx
@@ -7,14 +7,36 @@ interface AiBotModalProps {
 
 const AiBotModal: React.FC<AiBotModalProps> = ({ claimId }) => {
   return (
-    <div className="ai-bot-modal-overlay">
-      <div className="ai-bot-modal-container">
-        <div className="ai-bot-modal-spinner"></div>
-        <h2 className="ai-bot-modal-title">Running AI Bot</h2>
-        <p className="ai-bot-modal-subtitle">
-          Processing claim <span className="ai-bot-modal-claim-id">{claimId}</span>
-        </p>
+    <div className="ai-bot-modal-container">
+      <div className="ai-bot-modal-header">
+        <div className="ai-bot-modal-icon">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+            <polyline points="14 2 14 8 20 8"></polyline>
+            <line x1="16" y1="13" x2="8" y2="13"></line>
+            <line x1="16" y1="17" x2="8" y2="17"></line>
+            <polyline points="10 9 9 9 8 9"></polyline>
+          </svg>
+        </div>
+        <span className="ai-bot-modal-claim-id">{claimId}</span>
+        <span className="ai-bot-modal-percentage">73%</span>
       </div>
+      <div className="ai-bot-modal-progress-bar">
+        <div className="ai-bot-modal-progress" style={{ width: '73%' }}></div>
+      </div>
+      <p className="ai-bot-modal-description">
+        Processing claim for categorization and analysis...
+      </p>
     </div>
   );
 };

--- a/Kuve-AKU-1/src/components/ClaimsManagement.tsx
+++ b/Kuve-AKU-1/src/components/ClaimsManagement.tsx
@@ -101,7 +101,6 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedClaims, setSelectedClaims] = useState<string[]>([]);
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
-  const [isAiBotModalOpen, setIsAiBotModalOpen] = useState(false);
   const [processingClaimId, setProcessingClaimId] = useState<string | null>(null);
 
   const handleActionsClick = (claimId: string) => {
@@ -114,13 +113,12 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
 
   const handleRunAiBot = (claimId: string) => {
     setProcessingClaimId(claimId);
-    setIsAiBotModalOpen(true);
     setOpenMenuId(null); // Close the actions menu
 
+    // Simulate a 3-second process
     setTimeout(() => {
-      setIsAiBotModalOpen(false);
       setProcessingClaimId(null);
-    }, 3000); // Simulate a 3-second process
+    }, 3000);
   };
 
   const handleSelectAll = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -249,6 +247,7 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
         </div>
       </div>
 
+
       <div className="claims-table-container">
         <div className="claims-table-header">
           <div className="tabs">
@@ -304,57 +303,66 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
             </tr>
           </thead>
           <tbody>
-            {filteredClaims.map((claim, index) => (
-              <tr key={index}>
-                <td className="td-checkbox">
-                  <input
-                    type="checkbox"
-                    checked={selectedClaims.includes(claim.claimId)}
-                    onChange={() => handleSelectClaim(claim.claimId)}
-                  />
-                </td>
-                <td className="claim-id">{claim.claimId}</td>
-                <td>{claim.customer}</td>
-                <td><div className="pill-badge">{claim.provider}</div></td>
-                <td><div className="pill-badge">{claim.payer}</div></td>
-                <td className="date-issued">{claim.dateIssued}</td>
-                <td className="amount">{claim.amount}</td>
-                <td>
-                  <div className={`status-badge ${claim.status.toLowerCase().replace(' & ', '-').replace(' ', '-')}`}>
-                    <svg className="status-icon" fill="currentColor" viewBox="0 0 20 20">
-                      {claim.status === 'In Process' && <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.414-1.414L11 10.586V6z" clipRule="evenodd" />}
-                      {claim.status === 'Needs Review' && <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.414-1.414L11 10.586V6z" clipRule="evenodd" />}
-                      {claim.status === 'Approved & Sent' && <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />}
-                    </svg>
-                    {claim.status}
-                  </div>
-                </td>
-                <td className="actions-cell">
-                  <div className="actions-container">
-                    <svg
-                      className="actions-icon"
-                      xmlns="http://www.w3.org/2000/svg"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      onClick={() => handleActionsClick(claim.claimId)}
-                    >
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" />
-                    </svg>
-                    {openMenuId === claim.claimId && (
-                      <ActionsMenu onClose={handleCloseMenu} onRunAiBot={() => handleRunAiBot(claim.claimId)} />
-                    )}
-                  </div>
-                </td>
-              </tr>
-            ))}
+            {filteredClaims.map((claim, index) =>
+              processingClaimId === claim.claimId ? (
+                <tr key={`${claim.claimId}-processing`}>
+                  <td colSpan={9} style={{ padding: 0 }}>
+                    <AiBotModal claimId={claim.claimId} />
+                  </td>
+                </tr>
+              ) : (
+                <tr key={index}>
+                  <td className="td-checkbox">
+                    <input
+                      type="checkbox"
+                      checked={selectedClaims.includes(claim.claimId)}
+                      onChange={() => handleSelectClaim(claim.claimId)}
+                    />
+                  </td>
+                  <td className="claim-id">{claim.claimId}</td>
+                  <td>{claim.customer}</td>
+                  <td>
+                    <div className="pill-badge">{claim.provider}</div>
+                  </td>
+                  <td>
+                    <div className="pill-badge">{claim.payer}</div>
+                  </td>
+                  <td className="date-issued">{claim.dateIssued}</td>
+                  <td className="amount">{claim.amount}</td>
+                  <td>
+                    <div className={`status-badge ${claim.status.toLowerCase().replace(' & ', '-').replace(' ', '-')}`}>
+                      <svg className="status-icon" fill="currentColor" viewBox="0 0 20 20">
+                        {claim.status === 'In Process' && <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.414-1.414L11 10.586V6z" clipRule="evenodd" />}
+                        {claim.status === 'Needs Review' && <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.414-1.414L11 10.586V6z" clipRule="evenodd" />}
+                        {claim.status === 'Approved & Sent' && <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />}
+                      </svg>
+                      {claim.status}
+                    </div>
+                  </td>
+                  <td className="actions-cell">
+                    <div className="actions-container">
+                      <svg
+                        className="actions-icon"
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        onClick={() => handleActionsClick(claim.claimId)}
+                      >
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" />
+                      </svg>
+                      {openMenuId === claim.claimId && (
+                        <ActionsMenu onClose={handleCloseMenu} onRunAiBot={() => handleRunAiBot(claim.claimId)} />
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              )
+            )}
           </tbody>
         </table>
       </div>
       </div>
-      {isAiBotModalOpen && processingClaimId && (
-        <AiBotModal claimId={processingClaimId} />
-      )}
     </div>
     </>
   );


### PR DESCRIPTION
This commit replaces the AI Bot modal with a new inline component that is displayed within the claims table when a claim is being processed.

- The `AiBotModal` component has been restyled to match the new design.
- The `ClaimsManagement` component has been updated to render the `AiBotModal` component in place of the table row for the claim that is being processed.
- The state management for the modal has been preserved to ensure the component is displayed dynamically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inline AI processing row within the claims table replaces the separate popup, showing claim ID, percentage progress, and a status message.
  * Visual progress bar indicates processing completion in real time.

* **Style**
  * Refreshed AI processing UI with an icon header, rounded container, improved spacing, and clearer typography.
  * Removed spinner animation in favor of a cleaner progress indicator and muted descriptive text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->