### PR TITLE
feat: Update claim status after AI bot processing

### DIFF
--- a/Kuve-AKU-1/src/components/AiBotModal.css
+++ b/Kuve-AKU-1/src/components/AiBotModal.css
@@ -1,7 +1,14 @@
-.ai-bot-modal-wrapper {
+.ai-bot-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
   display: flex;
   justify-content: center;
-  margin-bottom: 24px;
+  align-items: center;
+  z-index: 2000;
 }
 
 .ai-bot-modal-container {

--- a/Kuve-AKU-1/src/components/AiBotModal.tsx
+++ b/Kuve-AKU-1/src/components/AiBotModal.tsx
@@ -3,9 +3,10 @@ import './AiBotModal.css';
 
 interface AiBotModalProps {
   claimId: string;
+  onComplete: () => void;
 }
 
-const AiBotModal: React.FC<AiBotModalProps> = ({ claimId }) => {
+const AiBotModal: React.FC<AiBotModalProps> = ({ claimId, onComplete }) => {
   const [progress, setProgress] = useState(0);
 
   useEffect(() => {
@@ -13,6 +14,7 @@ const AiBotModal: React.FC<AiBotModalProps> = ({ claimId }) => {
       setProgress(prevProgress => {
         if (prevProgress >= 100) {
           clearInterval(interval);
+          onComplete();
           return 100;
         }
         return prevProgress + 1;
@@ -20,39 +22,41 @@ const AiBotModal: React.FC<AiBotModalProps> = ({ claimId }) => {
     }, 30);
 
     return () => clearInterval(interval);
-  }, []);
+  }, [onComplete]);
 
   return (
-    <div className="ai-bot-modal-container">
-      <div className="ai-bot-modal-header">
-        <div className="ai-bot-modal-icon">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="20"
-            height="20"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
-            <polyline points="14 2 14 8 20 8"></polyline>
-            <line x1="16" y1="13" x2="8" y2="13"></line>
-            <line x1="16" y1="17" x2="8" y2="17"></line>
-            <polyline points="10 9 9 9 8 9"></polyline>
-          </svg>
+    <div className="ai-bot-modal-overlay">
+      <div className="ai-bot-modal-container">
+        <div className="ai-bot-modal-header">
+          <div className="ai-bot-modal-icon">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+              <polyline points="14 2 14 8 20 8"></polyline>
+              <line x1="16" y1="13" x2="8" y2="13"></line>
+              <line x1="16" y1="17" x2="8" y2="17"></line>
+              <polyline points="10 9 9 9 8 9"></polyline>
+            </svg>
+          </div>
+          <span className="ai-bot-modal-claim-id">{claimId}</span>
+          <span className="ai-bot-modal-percentage">{Math.round(progress)}%</span>
         </div>
-        <span className="ai-bot-modal-claim-id">{claimId}</span>
-        <span className="ai-bot-modal-percentage">{Math.round(progress)}%</span>
+        <div className="ai-bot-modal-progress-bar">
+          <div className="ai-bot-modal-progress" style={{ width: `${progress}%` }}></div>
+        </div>
+        <p className="ai-bot-modal-description">
+          Processing claim for categorization and analysis...
+        </p>
       </div>
-      <div className="ai-bot-modal-progress-bar">
-        <div className="ai-bot-modal-progress" style={{ width: `${progress}%` }}></div>
-      </div>
-      <p className="ai-bot-modal-description">
-        Processing claim for categorization and analysis...
-      </p>
     </div>
   );
 };

--- a/Kuve-AKU-1/src/components/ClaimsManagement.tsx
+++ b/Kuve-AKU-1/src/components/ClaimsManagement.tsx
@@ -31,7 +31,7 @@ const initialClaimsData = [
     payer: 'AIICO',
     dateIssued: '22-04-2025 10:40',
     amount: '$2,556',
-    status: 'Needs Review',
+    status: 'In Process',
   },
   {
     claimId: 'AKU-2025-334',
@@ -40,7 +40,7 @@ const initialClaimsData = [
     payer: 'AIICO',
     dateIssued: '06-05-2025 07:49',
     amount: '$3,625',
-    status: 'Needs Review',
+    status: 'In Process',
   },
     {
     claimId: 'AKU-2025-121',
@@ -49,7 +49,7 @@ const initialClaimsData = [
     payer: 'AIICO',
     dateIssued: '14-06-2025 19:08',
     amount: '$7,752',
-    status: 'Needs Review',
+    status: 'In Process',
   },
   {
     claimId: 'AKU-2025-004',
@@ -58,7 +58,7 @@ const initialClaimsData = [
     payer: 'AIICO',
     dateIssued: '17-07-2025 02:46',
     amount: '$8,322',
-    status: 'Approved & Sent',
+    status: 'In Process',
   },
     {
     claimId: 'AKU-2025-672',
@@ -67,7 +67,7 @@ const initialClaimsData = [
     payer: 'AIICO',
     dateIssued: '11-09-2025 02:46',
     amount: '$8,322',
-    status: 'Approved & Sent',
+    status: 'In Process',
   },
   {
     claimId: 'AKU-2025-009',
@@ -76,7 +76,7 @@ const initialClaimsData = [
     payer: 'AIICO',
     dateIssued: '13-09-2025 13:11',
     amount: '$9,027',
-    status: 'Approved & Sent',
+    status: 'In Process',
   },
   {
     claimId: 'AKU-2025-1431',
@@ -85,7 +85,7 @@ const initialClaimsData = [
     payer: 'AXA',
     dateIssued: '18-12-2025 22:51',
     amount: '$8,215',
-    status: 'Approved & Sent',
+    status: 'In Process',
   },
 ];
 
@@ -114,11 +114,15 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
   const handleRunAiBot = (claimId: string) => {
     setProcessingClaimId(claimId);
     setOpenMenuId(null); // Close the actions menu
+  };
 
-    // Simulate a 4-second process to allow animation to complete
-    setTimeout(() => {
-      setProcessingClaimId(null);
-    }, 4000);
+  const handleAiBotComplete = (claimId: string) => {
+    setClaimsData(prevClaims =>
+      prevClaims.map(claim =>
+        claim.claimId === claimId ? { ...claim, status: 'Needs Review' } : claim
+      )
+    );
+    setProcessingClaimId(null);
   };
 
   const handleSelectAll = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -248,9 +252,10 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
       </div>
 
       {processingClaimId && (
-        <div className="ai-bot-modal-wrapper">
-          <AiBotModal claimId={processingClaimId} />
-        </div>
+        <AiBotModal
+          claimId={processingClaimId}
+          onComplete={() => handleAiBotComplete(processingClaimId)}
+        />
       )}
       <div className="claims-table-container">
         <div className="claims-table-header">


### PR DESCRIPTION
This commit implements the logic to update the claim status in the table after the AI bot has finished processing.

- The default status of all claims in `initialClaimsData` has been set to "In Process".
- The `AiBotModal` component now accepts an `onComplete` callback prop, which is called when the loading animation finishes.
- In `ClaimsManagement.tsx`, a new handler function, `handleAiBotComplete`, updates the claim's status to "Needs Review" and hides the processing modal.
- The `setTimeout` that was previously used to hide the modal has been replaced with the new `onComplete` callback.