### PR TITLE
feat: Randomize claim status after AI bot processing

### DIFF
--- a/Kuve-AKU-1/src/components/ClaimsManagement.tsx
+++ b/Kuve-AKU-1/src/components/ClaimsManagement.tsx
@@ -117,9 +117,10 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
   };
 
   const handleAiBotComplete = (claimId: string) => {
+    const newStatus = Math.random() < 0.5 ? 'Needs Review' : 'Approved & Sent';
     setClaimsData(prevClaims =>
       prevClaims.map(claim =>
-        claim.claimId === claimId ? { ...claim, status: 'Needs Review' } : claim
+        claim.claimId === claimId ? { ...claim, status: newStatus } : claim
       )
     );
     setProcessingClaimId(null);


### PR DESCRIPTION
This commit updates the logic to randomly assign a new status to a claim after the AI bot has finished processing.

- The `handleAiBotComplete` function in `ClaimsManagement.tsx` now randomly selects between "Needs Review" and "Approved & Sent" as the new status for the claim.