### PR TITLE
feat: Conditionally render claims table header

### DIFF
--- a/Kuve-AKU-1/src/components/ClaimsManagement.css
+++ b/Kuve-AKU-1/src/components/ClaimsManagement.css
@@ -245,6 +245,41 @@
   color: #1976D2;
 }
 
+.table-actions.batch-actions {
+  justify-content: flex-end;
+}
+
+.run-ai-bot-btn {
+  background-color: #1976D2;
+  color: #FFFFFF;
+  border-color: #1976D2;
+  font-weight: 700;
+}
+
+.run-ai-bot-btn:hover {
+  background-color: #1565C0;
+}
+
+.run-ai-bot-btn .action-icon {
+  color: #FFFFFF;
+  width: 20px;
+  height: 20px;
+}
+
+.delete-btn {
+  background-color: #FFFFFF;
+  color: #EF4444;
+  border-color: #FECACA;
+}
+
+.delete-btn:hover {
+  background-color: #FEF2F2;
+}
+
+.delete-btn .action-icon {
+  color: #EF4444;
+}
+
 .claims-table-wrapper {
   overflow-x: auto;
 }

--- a/Kuve-AKU-1/src/components/ClaimsManagement.tsx
+++ b/Kuve-AKU-1/src/components/ClaimsManagement.tsx
@@ -116,6 +116,11 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
     setOpenMenuId(null); // Close the actions menu
   };
 
+  const handleRunBatchAiBot = () => {
+    // Functionality not in scope for this task.
+    console.log(`Batch AI bot run for ${selectedClaims.length} claims.`);
+  };
+
   const handleAiBotComplete = (claimId: string) => {
     const newStatus = Math.random() < 0.5 ? 'Needs Review' : 'Approved & Sent';
     setClaimsData(prevClaims =>
@@ -271,25 +276,42 @@ const ClaimsManagement: React.FC<ClaimsManagementProps> = ({ onUploadClaims, onO
               </button>
             ))}
           </div>
-          <div className="table-actions">
-            <div className="table-search-bar">
-              <svg xmlns="http://www.w3.org/2000/svg" className="search-icon" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clipRule="evenodd" /></svg>
-              <input
-                type="text"
-                placeholder="Type to search..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-              />
+          {selectedClaims.length > 1 ? (
+            <div className="table-actions batch-actions">
+              <button className="table-action-button delete-btn">
+                <svg className="action-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
+                Delete
+              </button>
+              <button className="table-action-button run-ai-bot-btn" onClick={handleRunBatchAiBot}>
+                <svg className="action-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25zm.09 15.57a.75.75 0 01-1.08-.02l-4.25-4.5a.75.75 0 111.1-1.04l3.7 3.92 6.7-6.91a.75.75 0 111.08 1.04l-7.25 7.5z" />
+                </svg>
+                Run AI Bot ({selectedClaims.length} Claims)
+              </button>
             </div>
-            <button className="table-action-button">
-              <svg className="action-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293.707L3.293 7.293A1 1 0 013 6.586V4z" /></svg>
-              Filter
-            </button>
-            <button className="table-action-button" onClick={exportToCsv}>
-              <svg className="action-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" /></svg>
-              Export
-            </button>
-          </div>
+          ) : (
+            <div className="table-actions">
+              <div className="table-search-bar">
+                <svg xmlns="http://www.w3.org/2000/svg" className="search-icon" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clipRule="evenodd" /></svg>
+                <input
+                  type="text"
+                  placeholder="Type to search..."
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                />
+              </div>
+              <button className="table-action-button">
+                <svg className="action-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293.707L3.293 7.293A1 1 0 013 6.586V4z" /></svg>
+                Filter
+              </button>
+              <button className="table-action-button" onClick={exportToCsv}>
+                <svg className="action-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" /></svg>
+                Export
+              </button>
+            </div>
+          )}
         </div>
       <div className="claims-table-wrapper">
         <table className="claims-table">


### PR DESCRIPTION
When multiple claims are selected, the table header now displays a 'Delete' and 'Run AI Bot' button, matching the provided design. This is achieved by conditionally rendering the header in the `ClaimsManagement` component based on the number of selected claims.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch actions in Claims Management when multiple claims are selected, including Delete and a Run AI Bot button showing the selected count.
  * Retains single-claim actions (Search, Filter, Export) and existing per-claim AI flow when fewer selections are made.

* **Style**
  * New styling for the batch actions area with right-aligned layout.
  * Primary styling and hover effects for the Run AI Bot button, including icon size/color updates.
  * Refined Delete button appearance with hover state and light red border.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->