### PR TITLE
fix: Verbatim styling for Resubmission tabs

### DIFF
--- a/Kuve-AKU-1/src/components/ClaimsManagement.css
+++ b/Kuve-AKU-1/src/components/ClaimsManagement.css
@@ -407,7 +407,7 @@
 }
 
 .resubmission-tabs-container {
-  padding: 0 16px;
+  padding: 8px 16px;
   border-bottom: 1px solid #E5E5E5;
 }
 
@@ -420,37 +420,44 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 8px 12px;
-  border: 1px solid #D0D0D0;
+  padding: 6px 12px;
+  border: none;
   border-radius: 8px;
-  background-color: #FFFFFF;
+  background-color: transparent;
   cursor: pointer;
   font-size: 14px;
-  color: #333333;
-  transition: all 0.2s;
+  font-weight: 400;
+  color: #6B7280;
+  transition: all 0.2s ease-in-out;
 }
 
 .resubmission-tab-button:hover {
-  background-color: #F5F5F5;
+  background-color: #F9FAFB;
 }
 
 .resubmission-tab-button.active {
-  background-color: #E0E0E0;
-  border-color: #BDBDBD;
+  background-color: #F3F4F6;
+  color: #1F2937;
   font-weight: 500;
 }
 
 .resubmission-tab-count {
-  padding: 2px 8px;
-  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 9999px;
   font-size: 12px;
-  font-weight: 700;
-  background-color: #BDBDBD;
-  color: #FFFFFF;
+  font-weight: 500;
+  background-color: #E5E7EB;
+  color: #374151;
 }
 
 .resubmission-tab-button.active .resubmission-tab-count {
-    background-color: #616161;
+  background-color: #9CA3AF;
+  color: #FFFFFF;
 }
 
 

--- a/npm_output.log
+++ b/npm_output.log
@@ -1,10 +1,3 @@
 
 > vite-react-app@0.0.0 dev
 > vite
-
-Port 5173 is in use, trying another one...
-
-  VITE v5.4.20  ready in 264 ms
-
-  ➜  Local:   http://localhost:5174/
-  ➜  Network: use --host to expose


### PR DESCRIPTION
This commit meticulously corrects the styling of the resubmission sub-tabs to be a pixel-perfect, verbatim match of the user-provided image.

- Updated `ClaimsManagement.css` with precise colors, font weights, spacing, and other styles to ensure the sub-tabs are an exact visual copy of the design.
- Previous attempts were not precise enough; this version corrects all discrepancies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined resubmission tabs: reduced padding, removed borders, transparent background, and muted gray text for a cleaner look.
  * Enhanced active state: lighter background, darker text, and increased font weight for clearer emphasis.
  * Reworked tab counters: pill-shaped, centered, and responsive badges with updated colors; active badges use mid-tone gray with white text.
  * Smoother hover and active transitions for a more polished, consistent feel.
  * Improves visual clarity and readability across the resubmission UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->