### PR TITLE
fix: Resolve 'cannot update component while rendering' warning

### DIFF
--- a/Kuve-AKU-1/src/components/AiBotModal.tsx
+++ b/Kuve-AKU-1/src/components/AiBotModal.tsx
@@ -11,18 +11,20 @@ const AiBotModal: React.FC<AiBotModalProps> = ({ claimId, onComplete }) => {
 
   useEffect(() => {
     const interval = setInterval(() => {
-      setProgress(prevProgress => {
-        if (prevProgress >= 100) {
-          clearInterval(interval);
-          onComplete();
-          return 100;
-        }
-        return prevProgress + 1;
-      });
+      setProgress(prevProgress => (prevProgress >= 100 ? 100 : prevProgress + 1));
     }, 30);
 
     return () => clearInterval(interval);
-  }, [onComplete]);
+  }, []);
+
+  useEffect(() => {
+    if (progress >= 100) {
+      const timer = setTimeout(() => {
+        onComplete();
+      }, 500); // Short delay to allow the progress bar to show 100%
+      return () => clearTimeout(timer);
+    }
+  }, [progress, onComplete]);
 
   return (
     <div className="ai-bot-modal-overlay">


### PR DESCRIPTION
This commit resolves a React warning that occurred when the `AiBotModal` component completed its process and called the `onComplete` callback.

The warning, "Cannot update a component (`ClaimsManagement`) while rendering a different component (`AiBotModal`)", was caused by the `onComplete` function being called directly within a `setProgress` state update, which triggered a state change in the parent component during the child's render cycle.

The fix refactors the `AiBotModal` to use a separate `useEffect` hook that monitors the `progress` state. The `onComplete` function is now called only when the progress reaches 100%, and this call is wrapped in a `setTimeout` to ensure it happens after the component has finished rendering. This resolves the warning and ensures a more stable state management flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the progress indicator reliably reaches and displays 100% before completion.
  * Prevents premature completion events, reducing flicker or abrupt modal closure.

* **Refactor**
  * Streamlined progress update logic for more predictable behavior.
  * Separated completion handling into a dedicated process for clearer timing and smoother UX.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->