### PR TITLE
style: Restyle 'Resubmit Claim' button

### DIFF
--- a/Kuve-AKU-1/src/components/ClaimsManagement.css
+++ b/Kuve-AKU-1/src/components/ClaimsManagement.css
@@ -422,14 +422,14 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 10px 20px;
+  padding: 8px 16px;
   border-radius: 9999px;
   border: none;
   background-color: #1976D2;
   color: #FFFFFF;
   font-family: 'Inter', sans-serif;
   font-size: 14px;
-  font-weight: 500;
+  font-weight: 700;
   cursor: pointer;
   transition: background-color 0.2s;
   margin-left: auto;


### PR DESCRIPTION
This commit updates the styling of the 'Resubmit Claim' button to align with the visual design of other primary action buttons in the application.

The following changes were made to the `.resubmit-claim-button` class in `ClaimsManagement.css`:
- The `padding` has been adjusted to `8px 16px`.
- The `font-weight` has been set to `700`.

These changes ensure a more consistent and polished user interface.